### PR TITLE
Fix MathJax not rendering in Chrome when sessionStorage is disabled.

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -768,11 +768,20 @@ MathJax.fileversion = "2.2";
       //  to be processed.
       //
       create: function (callback,node) {
+        // Accessing sessionStorage throws a SecurityError in Chrome is storage
+        // is disabled, thus breaking MathJax if the exception isn't caught.
+        sessionStorageCheck = function () {
+            try {
+                return typeof(window.sessionStorage);
+            } catch (exc) {
+                return "undefined";
+            }
+        }
         callback = BASE.Callback(callback);
         if (node.nodeName === "STYLE" && node.styleSheet &&
             typeof(node.styleSheet.cssText) !== 'undefined') {
           callback(this.STATUS.OK); // MSIE processes style immediately, but doesn't set its styleSheet!
-        } else if (window.chrome && typeof(window.sessionStorage) !== "undefined" &&
+        } else if (window.chrome && sessionStorageCheck() !== "undefined" &&
                    node.nodeName === "STYLE") {
           callback(this.STATUS.OK); // Same for Chrome 5 (beta), Grrr.
         } else if (isSafari2) {


### PR DESCRIPTION
If a user has disabled data storage, then accessing "window.sessionStorage" for the typeof throws a SecurityError, stopping MathJax from rendering. The solution is to simply wrap the access to window.sessioStorage in a try/catch and return "undefined" if it throws an exception.
