### PR TITLE
Center display math in XHTML (#650)

### DIFF
--- a/jax/output/NativeMML/config.js
+++ b/jax/output/NativeMML/config.js
@@ -12,5 +12,5 @@
  *      http://www.apache.org/licenses/LICENSE-2.0
  */
 
-MathJax.OutputJax.NativeMML=MathJax.OutputJax({id:"NativeMML",version:"2.2",directory:MathJax.OutputJax.directory+"/NativeMML",extensionDir:MathJax.OutputJax.extensionDir+"/NativeMML",config:{scale:100,minScaleAdjust:50,styles:{"DIV.MathJax_MathML":{"text-align":"center",margin:".75em 0px"}}}});if(!MathJax.Hub.config.delayJaxRegistration){MathJax.OutputJax.NativeMML.Register("jax/mml")}MathJax.OutputJax.NativeMML.loadComplete("config.js");
+MathJax.OutputJax.NativeMML=MathJax.OutputJax({id:"NativeMML",version:"2.2",directory:MathJax.OutputJax.directory+"/NativeMML",extensionDir:MathJax.OutputJax.extensionDir+"/NativeMML",config:{scale:100,minScaleAdjust:50,styles:{"div.MathJax_MathML":{"text-align":"center",margin:".75em 0px"}}}});if(!MathJax.Hub.config.delayJaxRegistration){MathJax.OutputJax.NativeMML.Register("jax/mml")}MathJax.OutputJax.NativeMML.loadComplete("config.js");
 

--- a/unpacked/jax/output/NativeMML/config.js
+++ b/unpacked/jax/output/NativeMML/config.js
@@ -36,7 +36,7 @@ MathJax.OutputJax.NativeMML = MathJax.OutputJax({
     minScaleAdjust: 50,      // minimum scaling to adjust to surrounding text
                              //  (since the code for that is a bit delicate)
     styles: {
-      "DIV.MathJax_MathML": {
+      "div.MathJax_MathML": {
         "text-align": "center",
         margin: ".75em 0px"
       }


### PR DESCRIPTION
The DIV was capital.  It should be small to work in XHTML.
