### PR TITLE
Typo in English message fixed

### DIFF
--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -1733,7 +1733,7 @@
         if (++this.macroCount > TEX.config.MAXMACROS) {
           TEX.Error(["MaxMacroSub2",
                      "MathJax maximum substitution count exceeded; " +
-                     "is there a recursive latex environment?"]);
+                     "is there a recursive LaTeX environment?"]);
         }
         if (cmd[0] && this[cmd[0]]) {mml = this[cmd[0]].apply(this,[mml].concat(cmd.slice(2)))}
       }

--- a/unpacked/localization/en/TeX.js
+++ b/unpacked/localization/en/TeX.js
@@ -52,7 +52,7 @@ MathJax.Localization.addTranslation("en","TeX",{
           InvalidMathMLAttr: "Invalid MathML attribute: %1",
           UnknownAttrForElement: "%1 is not a recognized attribute for %2",
           MaxMacroSub1: "MathJax maximum macro substitution count exceeded; is there a recursive macro call?",
-          MaxMacroSub2: "MathJax maximum substitution count exceeded; is there a recursive latex environment?",
+          MaxMacroSub2: "MathJax maximum substitution count exceeded; is there a recursive LaTeX environment?",
           MissingArgFor: "Missing argument for %1",
           ExtraAlignTab: "Extra alignment tab in \\cases text",
           BracketMustBeDimension: "Bracket argument to %1 must be a dimension",


### PR DESCRIPTION
Changes _latex_ to _LaTeX_ in the `MaxMacroSub2`-message (issue #852)
