### PR TITLE
Normalise MathJax.Callback to MathJax.CallBack

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -586,13 +586,13 @@ MathJax.cdnFileVersions = {};       // can be used to specify revisions for indi
   //
   //  The main entry-points
   //
-  BASE.Callback = BASE.CallBack = USING;
-  BASE.Callback.Delay = DELAY;
-  BASE.Callback.After = AFTER;
-  BASE.Callback.Queue = QUEUE;
-  BASE.Callback.Signal = SIGNAL.find;
-  BASE.Callback.Hooks = HOOKS;
-  BASE.Callback.ExecuteHooks = EXECUTEHOOKS;
+  BASE.CallBack = USING;
+  BASE.CallBack.Delay = DELAY;
+  BASE.CallBack.After = AFTER;
+  BASE.CallBack.Queue = QUEUE;
+  BASE.CallBack.Signal = SIGNAL.find;
+  BASE.CallBack.Hooks = HOOKS;
+  BASE.CallBack.ExecuteHooks = EXECUTEHOOKS;
 })("MathJax");
 
 
@@ -686,7 +686,7 @@ MathJax.cdnFileVersions = {};       // can be used to specify revisions for indi
     //  Make sure the file URL is "safe"?
     //
     Require: function (file,callback) {
-      callback = BASE.Callback(callback); var type;
+      callback = BASE.CallBack(callback); var type;
       if (file instanceof Object) {
         for (var i in file)
           {if (file.hasOwnProperty(i)) {type = i.toUpperCase(); file = file[i]}}
@@ -707,7 +707,7 @@ MathJax.cdnFileVersions = {};       // can be used to specify revisions for indi
     //  already been loaded.
     //
     Load: function (file,callback) {
-      callback = BASE.Callback(callback); var type;
+      callback = BASE.CallBack(callback); var type;
       if (file instanceof Object) {
         for (var i in file)
           {if (file.hasOwnProperty(i)) {type = i.toUpperCase(); file = file[i]}}
@@ -728,7 +728,7 @@ MathJax.cdnFileVersions = {};       // can be used to specify revisions for indi
     //  loadComplete() is called for that file)
     //
     LoadHook: function (file,callback,priority) {
-      callback = BASE.Callback(callback);
+      callback = BASE.CallBack(callback);
       if (file instanceof Object)
         {for (var i in file) {if (file.hasOwnProperty(i)) {file = file[i]}}}
       file = this.fileURL(file);
@@ -737,7 +737,7 @@ MathJax.cdnFileVersions = {};       // can be used to specify revisions for indi
       return callback;
     },
     addHook: function (file,callback,priority) {
-      if (!this.loadHooks[file]) {this.loadHooks[file] = MathJax.Callback.Hooks()}
+      if (!this.loadHooks[file]) {this.loadHooks[file] = MathJax.CallBack.Hooks()}
       this.loadHooks[file].Add(callback,priority);
     },
     
@@ -762,7 +762,7 @@ MathJax.cdnFileVersions = {};       // can be used to specify revisions for indi
       JS: function (file,callback) {
         var name = this.fileName(file);
         var script = document.createElement("script");
-        var timeout = BASE.Callback(["loadTimeout",this,file]);
+        var timeout = BASE.CallBack(["loadTimeout",this,file]);
         this.loading[file] = {
           callback: callback,
           timeout: setTimeout(timeout,this.timeout),
@@ -807,7 +807,7 @@ MathJax.cdnFileVersions = {};       // can be used to specify revisions for indi
       //  to be processed.
       //
       create: function (callback,node) {
-        callback = BASE.Callback(callback);
+        callback = BASE.CallBack(callback);
         if (node.nodeName === "STYLE" && node.styleSheet &&
             typeof(node.styleSheet.cssText) !== 'undefined') {
           callback(this.STATUS.OK); // MSIE processes style immediately, but doesn't set its styleSheet!
@@ -825,7 +825,7 @@ MathJax.cdnFileVersions = {};       // can be used to specify revisions for indi
       //  Start the timer for the given callback checker
       //
       start: function (AJAX,check,delay,timeout) {
-        check = BASE.Callback(check);
+        check = BASE.CallBack(check);
         check.execute = this.execute; check.time = this.time;
         check.STATUS = AJAX.STATUS; check.timeout = timeout || AJAX.timeout;
         check.delay = check.total = delay || 0;
@@ -881,7 +881,7 @@ MathJax.cdnFileVersions = {};       // can be used to specify revisions for indi
         }
         if (isStyle) {
           // Opera 9.6 requires this setTimeout
-          setTimeout(BASE.Callback([callback,check.STATUS.OK]),0);
+          setTimeout(BASE.CallBack([callback,check.STATUS.OK]),0);
         } else {
           setTimeout(check,check.delay);
         }
@@ -941,7 +941,7 @@ MathJax.cdnFileVersions = {};       // can be used to specify revisions for indi
     Styles: function (styles,callback) {
       var styleString = this.StyleString(styles);
       if (styleString === "") {
-        callback = BASE.Callback(callback);
+        callback = BASE.CallBack(callback);
         callback();
       } else {
         var style = document.createElement("style"); style.type = "text/css";
@@ -1397,7 +1397,7 @@ MathJax.Localization = {
   //  directory and file.
   //
   loadFile: function (file,data,callback) {
-    callback = MathJax.Callback(callback);
+    callback = MathJax.CallBack(callback);
     file = (data.file || file);  // the data's file name or the default name
     if (!file.match(/\.js$/)) {file += ".js"} // add .js if needed
     //
@@ -1434,7 +1434,7 @@ MathJax.Localization = {
       if (!localeData.isLoaded) {
         load = this.loadFile(this.locale,localeData);
         if (load) {
-          return MathJax.Callback.Queue(
+          return MathJax.CallBack.Queue(
             load,["loadDomain",this,domain] // call again to load domain
           ).Push(callback||{});
         }
@@ -1443,12 +1443,12 @@ MathJax.Localization = {
         var domainData = localeData.domains[domain];
         if (!domainData.isLoaded) {
           load = this.loadFile(domain,domainData);
-          if (load) {return MathJax.Callback.Queue(load).Push(callback)}
+          if (load) {return MathJax.CallBack.Queue(load).Push(callback)}
         }
       }
     } 
     // localization data are loaded, so just do the callback
-    return MathJax.Callback(callback)();
+    return MathJax.CallBack(callback)();
   },
 
   //
@@ -1461,10 +1461,10 @@ MathJax.Localization = {
   //  can be used to synchronize it with other actions.)
   //
   Try: function (fn) {
-    fn = MathJax.Callback(fn); fn.autoReset = true;
+    fn = MathJax.CallBack(fn); fn.autoReset = true;
     try {fn()} catch (err) {
       if (!err.restart) {throw err}
-      MathJax.Callback.After(["Try",this,fn],err.restart);
+      MathJax.CallBack.After(["Try",this,fn],err.restart);
     }
   },
 
@@ -1691,7 +1691,7 @@ MathJax.Message = {
           //
           if (this.log[n].restarted == null) {this.log[n].restarted = 0}
           this.log[n].restarted++; delete this.log[n].cleared;
-          MathJax.Callback.After(["Set",this,text,n,clearDelay],err.restart);
+          MathJax.CallBack.After(["Set",this,text,n,clearDelay],err.restart);
           return n;
         }
       }
@@ -1737,7 +1737,7 @@ MathJax.Message = {
     //
     //  Check if we need to clear the message automatically.
     //
-    if (clearDelay) {setTimeout(MathJax.Callback(["Clear",this,n]),clearDelay)}
+    if (clearDelay) {setTimeout(MathJax.CallBack(["Clear",this,n]),clearDelay)}
       else if (clearDelay == 0) {this.Clear(n,0)}
     //
     //  Return the message number.
@@ -1765,7 +1765,7 @@ MathJax.Message = {
           if (this.timer) {clearTimeout(this.timer); delete this.timer}
           if (delay == null) {delay = 600}
           if (delay === 0) {this.Remove()}
-	    else {this.timer = setTimeout(MathJax.Callback(["Remove",this]),delay)}
+	    else {this.timer = setTimeout(MathJax.CallBack(["Remove",this]),delay)}
         } else if (MathJax.Hub.config.messageStyle !== "none") {
           //
           //  If there is an old message, put it in place
@@ -1863,14 +1863,14 @@ MathJax.Hub = {
     }
   },
   
-  preProcessors: MathJax.Callback.Hooks(true), // list of callbacks for preprocessing (initialized by extensions)
+  preProcessors: MathJax.CallBack.Hooks(true), // list of callbacks for preprocessing (initialized by extensions)
   inputJax: {},          // mime-type mapped to input jax (by registration)
   outputJax: {order:{}}, // mime-type mapped to output jax list (by registration)
 
   processUpdateTime: 250, // time between screen updates when processing math (milliseconds)
   processUpdateDelay: 10, // pause between screen updates to allow other processing (milliseconds)
 
-  signal: MathJax.Callback.Signal("Hub"), // Signal used for Hub events
+  signal: MathJax.CallBack.Signal("Hub"), // Signal used for Hub events
 
   Config: function (def) {
     this.Insert(this.config,def);
@@ -1970,7 +1970,7 @@ MathJax.Hub = {
   Typeset: function (element,callback) {
     if (!MathJax.isReady) return null;
     var ec = this.elementCallback(element,callback);
-    var queue = MathJax.Callback.Queue();
+    var queue = MathJax.CallBack.Queue();
     for (var i = 0, m = ec.elements.length; i < m; i++) {
       if (ec.elements[i]) {
         queue.Push(
@@ -1984,7 +1984,7 @@ MathJax.Hub = {
   
   PreProcess: function (element,callback) {
     var ec = this.elementCallback(element,callback);
-    var queue = MathJax.Callback.Queue();
+    var queue = MathJax.CallBack.Queue();
     for (var i = 0, m = ec.elements.length; i < m; i++) {
       if (ec.elements[i]) {
         queue.Push(
@@ -2004,7 +2004,7 @@ MathJax.Hub = {
   
   takeAction: function (action,element,callback) {
     var ec = this.elementCallback(element,callback);
-    var queue = MathJax.Callback.Queue(["Clear",this.signal]);
+    var queue = MathJax.CallBack.Queue(["Clear",this.signal]);
     for (var i = 0, m = ec.elements.length; i < m; i++) {
       if (ec.elements[i]) {
         var state = {
@@ -2136,7 +2136,7 @@ MathJax.Hub = {
         //
         state.i++; var now = new Date().getTime();
         if (now - state.start > this.processUpdateTime && state.i < state.scripts.length)
-          {state.start = now; this.RestartAfter(MathJax.Callback.Delay(1))}
+          {state.start = now; this.RestartAfter(MathJax.CallBack.Delay(1))}
       }
     } catch (err) {return this.processError(err,state,"Input")}
     //
@@ -2199,7 +2199,7 @@ MathJax.Hub = {
             MathJax.Hub.lastPrepError = err;
             state.j++;
           }
-          return MathJax.Callback.After(["prepareOutput",this,state,method],err.restart);
+          return MathJax.CallBack.After(["prepareOutput",this,state,method],err.restart);
         }
       }
       state.j++;
@@ -2236,7 +2236,7 @@ MathJax.Hub = {
         //
         var now = new Date().getTime();
         if (now - state.start > this.processUpdateTime && state.i < state.scripts.length)
-          {state.start = now; this.RestartAfter(MathJax.Callback.Delay(this.processUpdateDelay))}
+          {state.start = now; this.RestartAfter(MathJax.CallBack.Delay(this.processUpdateDelay))}
       }
     } catch (err) {return this.processError(err,state,"Output")}
     //
@@ -2263,7 +2263,7 @@ MathJax.Hub = {
       this.formatError(state.scripts[state.i],err); state.i++;
     }
     this.processMessage(state,type);
-    return MathJax.Callback.After(["process"+type,this,state],err.restart);
+    return MathJax.CallBack.After(["process"+type,this,state],err.restart);
   },
   
   formatError: function (script,err) {
@@ -2309,12 +2309,12 @@ MathJax.Hub = {
   },
   
   RestartAfter: function (callback) {
-    throw this.Insert(Error("restart"),{restart: MathJax.Callback(callback)});
+    throw this.Insert(Error("restart"),{restart: MathJax.CallBack(callback)});
   },
   
   elementCallback: function (element,callback) {
     if (callback == null && (element instanceof Array || typeof element === 'function'))
-      {try {MathJax.Callback(element); callback = element; element = null} catch(e) {}}
+      {try {MathJax.CallBack(element); callback = element; element = null} catch(e) {}}
     if (element == null) {element = this.config.elements || []}
     if (!(element instanceof Array)) {element = [element]}
     element = [].concat(element); // make a copy so the original isn't changed
@@ -2370,11 +2370,11 @@ MathJax.Extension = {};
 //
 //  Hub Startup code
 //
-MathJax.Hub.Configured = MathJax.Callback({}); // called when configuration is complete
+MathJax.Hub.Configured = MathJax.CallBack({}); // called when configuration is complete
 MathJax.Hub.Startup = {
   script: "", // the startup script from the SCRIPT call that loads MathJax.js
-  queue:   MathJax.Callback.Queue(),           // Queue used for startup actions
-  signal:  MathJax.Callback.Signal("Startup"), // Signal used for startup events
+  queue:   MathJax.CallBack.Queue(),           // Queue used for startup actions
+  signal:  MathJax.CallBack.Signal("Startup"), // Signal used for startup events
   params:  {},
 
   //
@@ -2432,7 +2432,7 @@ MathJax.Hub.Startup = {
   //
   ConfigBlocks: function () {
     var scripts = document.getElementsByTagName("script");
-    var last = null, queue = MathJax.Callback.Queue();
+    var last = null, queue = MathJax.CallBack.Queue();
     for (var i = 0, m = scripts.length; i < m; i++) {
       var type = String(scripts[i].type).replace(/ /g,"");
       if (type.match(/^text\/x-mathjax-config(;.*)?$/) && !type.match(/;executed=true/)) {
@@ -2492,7 +2492,7 @@ MathJax.Hub.Startup = {
       if (config.jax[i].substr(0,7) === "output/" && jax.order[name] == null)
         {jax.order[name] = k; k++}
     }
-    var queue = MathJax.Callback.Queue();
+    var queue = MathJax.CallBack.Queue();
     return queue.Push(
       ["Post",this.signal,"Begin Jax"],
       ["loadArray",this,config.jax,"jax","config.js"],
@@ -2503,7 +2503,7 @@ MathJax.Hub.Startup = {
   //  Load the extensions
   //
   Extensions: function () {
-    var queue = MathJax.Callback.Queue();
+    var queue = MathJax.CallBack.Queue();
     return queue.Push(
       ["Post",this.signal,"Begin Extensions"],
       ["loadArray",this,MathJax.Hub.config.extensions,"extensions"],
@@ -2575,7 +2575,7 @@ MathJax.Hub.Startup = {
       if (!MathJax.Extension.MathMenu) {
         setTimeout(
           function () {
-            MathJax.Callback.Queue(
+            MathJax.CallBack.Queue(
               ["Require",MathJax.Ajax,"[MathJax]/extensions/MathMenu.js",{}],
               ["loadDomain",MathJax.Localization,"MathMenu"]
             )
@@ -2583,13 +2583,13 @@ MathJax.Hub.Startup = {
         );
       } else {
         setTimeout(
-          MathJax.Callback(["loadDomain",MathJax.Localization,"MathMenu"]),
+          MathJax.CallBack(["loadDomain",MathJax.Localization,"MathMenu"]),
           1000
         );
       }
       if (!MathJax.Extension.MathZoom) {
         setTimeout(
-          MathJax.Callback(["Require",MathJax.Ajax,"[MathJax]/extensions/MathZoom.js",{}]),
+          MathJax.CallBack(["Require",MathJax.Ajax,"[MathJax]/extensions/MathZoom.js",{}]),
           2000
         );
       }
@@ -2601,7 +2601,7 @@ MathJax.Hub.Startup = {
   //
   onLoad: function () {
     var onload = this.onload =
-      MathJax.Callback(function () {MathJax.Hub.Startup.signal.Post("onLoad")});
+      MathJax.CallBack(function () {MathJax.Hub.Startup.signal.Post("onLoad")});
     if (document.body && document.readyState)
       if (MathJax.Hub.Browser.isMSIE) {
         // IE can change from loading to interactive before
@@ -2647,7 +2647,7 @@ MathJax.Hub.Startup = {
     if (files) {
       if (!(files instanceof Array)) {files = [files]}
       if (files.length) {
-        var queue = MathJax.Callback.Queue(), callback = {}, file;
+        var queue = MathJax.CallBack.Queue(), callback = {}, file;
         for (var i = 0, m = files.length; i < m; i++) {
           file = this.URL(dir,files[i]);
           if (name) {file += "/" + name}
@@ -2667,7 +2667,7 @@ MathJax.Hub.Startup = {
 
 (function (BASENAME) {
   var BASE = window[BASENAME], ROOT = "["+BASENAME+"]";
-  var HUB = BASE.Hub, AJAX = BASE.Ajax, CALLBACK = BASE.Callback;
+  var HUB = BASE.Hub, AJAX = BASE.Ajax, CALLBACK = BASE.CallBack;
 
   var JAX = MathJax.Object.Subclass({
     JAXFILE: "jax.js",
@@ -3097,7 +3097,7 @@ MathJax.Hub.Startup = {
   HUB.Browser.Select(MathJax.Message.browsers);
 
   if (BASE.AuthorConfig && typeof BASE.AuthorConfig.AuthorInit === "function") {BASE.AuthorConfig.AuthorInit()}
-  HUB.queue = BASE.Callback.Queue();
+  HUB.queue = BASE.CallBack.Queue();
   HUB.queue.Push(
     ["Post",STARTUP.signal,"Begin"],
     ["Config",STARTUP],
@@ -3106,7 +3106,7 @@ MathJax.Hub.Startup = {
     ["Message",STARTUP],
     function () {
       // Do Jax and Extensions in parallel, but wait for them all to complete
-      var queue = BASE.Callback.Queue(
+      var queue = BASE.CallBack.Queue(
         STARTUP.Jax(),
         STARTUP.Extensions()
       );

--- a/unpacked/extensions/HelpDialog.js
+++ b/unpacked/extensions/HelpDialog.js
@@ -144,7 +144,7 @@
     if (HELP.div) {document.body.removeChild(HELP.div); delete HELP.div}
   };
 
-  MathJax.Callback.Queue(
+  MathJax.CallBack.Queue(
     HUB.Register.StartupHook("End Config",{}), // wait until config is complete
     ["Styles",AJAX,CONFIG.styles],
     ["Post",HUB.Startup.signal,"HelpDialig Ready"],

--- a/unpacked/extensions/MathEvents.js
+++ b/unpacked/extensions/MathEvents.js
@@ -567,5 +567,5 @@
     ["loadComplete",AJAX,"[MathJax]/extensions/MathEvents.js"]
   );
   
-})(MathJax.Hub,MathJax.HTML,MathJax.Ajax,MathJax.Callback,
+})(MathJax.Hub,MathJax.HTML,MathJax.Ajax,MathJax.CallBack,
    MathJax.Localization,MathJax.OutputJax,MathJax.InputJax);

--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -29,7 +29,7 @@
 (function (HUB,HTML,AJAX,CALLBACK,OUTPUT) {
   var VERSION = "2.4.0";
 
-  var SIGNAL = MathJax.Callback.Signal("menu")  // signal for menu events
+  var SIGNAL = MathJax.CallBack.Signal("menu")  // signal for menu events
   
   MathJax.Extension.MathMenu = {
     version: VERSION,

--- a/unpacked/extensions/MathZoom.js
+++ b/unpacked/extensions/MathZoom.js
@@ -352,7 +352,7 @@
 
   /*************************************************************/
 
-  MathJax.Callback.Queue(
+  MathJax.CallBack.Queue(
     ["StartupHook",MathJax.Hub.Register,"Begin Styles",{}],
     ["Styles",AJAX,CONFIG.styles],
     ["Post",HUB.Startup.signal,"MathZoom Ready"],

--- a/unpacked/extensions/TeX/autoload-all.js
+++ b/unpacked/extensions/TeX/autoload-all.js
@@ -77,7 +77,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
   
 });
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["Require",MathJax.Ajax,"[MathJax]/extensions/TeX/AMSsymbols.js"],
   ["loadComplete",MathJax.Ajax,"[MathJax]/extensions/TeX/autoload-all.js"]
 );

--- a/unpacked/jax/input/AsciiMath/jax.js
+++ b/unpacked/jax/input/AsciiMath/jax.js
@@ -1278,8 +1278,8 @@ junk = null;
     sourceMenuTitle: /*_(MathMenu)*/ ["AsciiMathInput","AsciiMath Input"],
     annotationEncoding: "text/x-asciimath",
 
-    prefilterHooks:    MathJax.Callback.Hooks(true),   // hooks to run before processing AsciiMath
-    postfilterHooks:   MathJax.Callback.Hooks(true),   // hooks to run after processing AsciiMath
+    prefilterHooks:    MathJax.CallBack.Hooks(true),   // hooks to run before processing AsciiMath
+    postfilterHooks:   MathJax.CallBack.Hooks(true),   // hooks to run after processing AsciiMath
 
     Translate: function (script) {
       var mml, math = MathJax.HTML.getScript(script);

--- a/unpacked/jax/input/MathML/jax.js
+++ b/unpacked/jax/input/MathML/jax.js
@@ -238,8 +238,8 @@
   MATHML.Augment({
     sourceMenuTitle: /*_(MathMenu)*/ ["OriginalMathML","Original MathML"],
     
-    prefilterHooks:    MathJax.Callback.Hooks(true),   // hooks to run before processing MathML
-    postfilterHooks:   MathJax.Callback.Hooks(true),   // hooks to run after processing MathML
+    prefilterHooks:    MathJax.CallBack.Hooks(true),   // hooks to run before processing MathML
+    postfilterHooks:   MathJax.CallBack.Hooks(true),   // hooks to run after processing MathML
 
     Translate: function (script) {
       if (!this.ParseXML) {this.ParseXML = this.createParser()}

--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -2064,8 +2064,8 @@
     sourceMenuTitle: /*_(MathMenu)*/ ["TeXCommands","TeX Commands"],
     annotationEncoding: "application/x-tex",
 
-    prefilterHooks: MathJax.Callback.Hooks(true),    // hooks to run before processing TeX
-    postfilterHooks: MathJax.Callback.Hooks(true),   // hooks to run after processing TeX
+    prefilterHooks: MathJax.CallBack.Hooks(true),    // hooks to run before processing TeX
+    postfilterHooks: MathJax.CallBack.Hooks(true),   // hooks to run after processing TeX
     
     //
     //  Check if AMSmath extension must be loaded and push

--- a/unpacked/jax/output/HTML-CSS/autoload/maction.js
+++ b/unpacked/jax/output/HTML-CSS/autoload/maction.js
@@ -91,13 +91,13 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
     HTMLaction: {
       toggle: function (span,frame,selection) {
         this.selection = selection;
-        frame.onclick = span.childNodes[1].onclick = MathJax.Callback(["HTMLclick",this]);
+        frame.onclick = span.childNodes[1].onclick = MathJax.CallBack(["HTMLclick",this]);
         frame.style.cursor = span.childNodes[1].style.cursor="pointer";
       },
       
       statusline: function (span,frame,selection) {
-        frame.onmouseover = span.childNodes[1].onmouseover = MathJax.Callback(["HTMLsetStatus",this]);
-        frame.onmouseout  = span.childNodes[1].onmouseout  = MathJax.Callback(["HTMLclearStatus",this]);
+        frame.onmouseover = span.childNodes[1].onmouseover = MathJax.CallBack(["HTMLsetStatus",this]);
+        frame.onmouseout  = span.childNodes[1].onmouseout  = MathJax.CallBack(["HTMLclearStatus",this]);
         frame.onmouseover.autoReset = frame.onmouseout.autoReset = true;
       },
       
@@ -106,8 +106,8 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
           frame.title = frame.alt = span.childNodes[1].title =
             span.childNodes[1].alt = this.data[1].data.join("");
         } else {
-          frame.onmouseover = span.childNodes[1].onmouseover = MathJax.Callback(["HTMLtooltipOver",this]);
-          frame.onmouseout  = span.childNodes[1].onmouseout  = MathJax.Callback(["HTMLtooltipOut",this]);
+          frame.onmouseover = span.childNodes[1].onmouseover = MathJax.CallBack(["HTMLtooltipOver",this]);
+          frame.onmouseout  = span.childNodes[1].onmouseout  = MathJax.CallBack(["HTMLtooltipOut",this]);
           frame.onmouseover.autoReset = frame.onmouseout.autoReset = true;
         }
       }
@@ -156,13 +156,13 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
         x = event.clientX + document.body.scrollLeft + document.documentElement.scrollLeft;
         y = event.clientY + document.body.scrollTop + document.documentElement.scrollTop;
       }
-      var callback = MathJax.Callback(["HTMLtooltipPost",this,x+CONFIG.offsetX,y+CONFIG.offsetY])
+      var callback = MathJax.CallBack(["HTMLtooltipPost",this,x+CONFIG.offsetX,y+CONFIG.offsetY])
       hover = setTimeout(callback,CONFIG.delayPost);
     },
     HTMLtooltipOut: function (event) {
       if (hover) {clearTimeout(hover); hover = null}
       if (clear) {clearTimeout(clear)}
-      var callback = MathJax.Callback(["HTMLtooltipClear",this,80]);
+      var callback = MathJax.CallBack(["HTMLtooltipClear",this,80]);
       clear = setTimeout(callback,CONFIG.delayClear);
     },
     HTMLtooltipPost: function (x,y) {
@@ -189,7 +189,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
       try {HTMLCSS.Measured(this.data[1].toHTML(box),box)} catch(err) {
         if (!err.restart) {throw err}
         tip.style.display = "none";
-        MathJax.Callback.After(["HTMLtooltipPost",this,x,y],err.restart);
+        MathJax.CallBack.After(["HTMLtooltipPost",this,x,y],err.restart);
         return;
       }
       HTMLCSS.placeBox(box,0,0);
@@ -205,7 +205,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
       } else {
         tip.style.opacity = n/100;
         tip.style.filter = "alpha(opacity="+n+")";
-        clear = setTimeout(MathJax.Callback(["HTMLtooltipClear",this,n-20]),50);
+        clear = setTimeout(MathJax.CallBack(["HTMLtooltipClear",this,n-20]),50);
       }
     }
   });

--- a/unpacked/jax/output/HTML-CSS/autoload/mglyph.js
+++ b/unpacked/jax/output/HTML-CSS/autoload/mglyph.js
@@ -56,8 +56,8 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
         if (!this.img) {
           this.img = MML.mglyph.GLYPH[values.src] = {img: new Image(), status: "pending"};
           var img = this.img.img;
-          img.onload = MathJax.Callback(["HTMLimgLoaded",this]);
-          img.onerror = MathJax.Callback(["HTMLimgError",this]);
+          img.onload = MathJax.CallBack(["HTMLimgLoaded",this]);
+          img.onerror = MathJax.CallBack(["HTMLimgError",this]);
           img.src = values.src;
           MathJax.Hub.RestartAfter(img.onload);
         }

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Alphabets/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Alphabets/Regular/Main.js
@@ -164,7 +164,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Alphabets'] = {
   0x10147: [700,0,671,55,630]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Alphabets"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Alphabets/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Arrows/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Arrows/Regular/Main.js
@@ -214,7 +214,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Arrows'] = {
   0x297F: [608,66,743,66,678]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Arrows"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Arrows/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/DoubleStruck/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/DoubleStruck/Regular/Main.js
@@ -96,7 +96,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_DoubleStruck'] = {
   0x1D7E1: [679,17,600,38,562]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_DoubleStruck"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/DoubleStruck/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Fraktur/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Fraktur/Regular/Main.js
@@ -126,7 +126,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Fraktur'] = {
   0x1D59F: [541,168,374,36,345]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Fraktur"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Fraktur/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Latin/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Latin/Regular/Main.js
@@ -103,7 +103,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Latin'] = {
   0xFF: [637,283,555,12,544]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Latin"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Latin/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Main/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Main/Regular/Main.js
@@ -538,7 +538,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Main'] = {
   0x2ACC: [669,183,668,55,615]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Main"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Main/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Marks/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Marks/Regular/Main.js
@@ -85,7 +85,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Marks'] = {
   0x3019: [730,212,384,77,308]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Marks"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Marks/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Misc/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Misc/Regular/Main.js
@@ -106,7 +106,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Misc'] = {
   0x2736: [572,0,592,45,547]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Misc"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Misc/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Monospace/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Monospace/Regular/Main.js
@@ -87,7 +87,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Monospace'] = {
   0x1D7FF: [691,12,499,50,449]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Monospace"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Monospace/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/NonUnicode/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/NonUnicode/Regular/Main.js
@@ -304,7 +304,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_NonUnicode'] = {
   0xE117: [469,283,233,-40,159]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_NonUnicode"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/NonUnicode/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Normal/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Normal/Regular/Main.js
@@ -366,7 +366,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Normal'] = {
   0x1D7D7: [689,18,499,31,463]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Normal"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Normal/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Operators/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Operators/Regular/Main.js
@@ -344,7 +344,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Operators'] = {
   0x2AFF: [654,112,383,64,320]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Operators"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Operators/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/SansSerif/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/SansSerif/Regular/Main.js
@@ -370,7 +370,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_SansSerif'] = {
   0x1D7F5: [689,21,549,46,503]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_SansSerif"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/SansSerif/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Script/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Script/Regular/Main.js
@@ -128,7 +128,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Script'] = {
   0x1D503: [494,18,799,59,742]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Script"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Script/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Shapes/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Shapes/Regular/Main.js
@@ -108,7 +108,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Shapes'] = {
   0x2B52: [458,2,554,35,519]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Shapes"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Shapes/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Size1/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Size1/Regular/Main.js
@@ -112,7 +112,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Size1'] = {
   0x2A1C: [1471,654,1156,80,1037]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Size1"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size1/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Size2/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Size2/Regular/Main.js
@@ -112,7 +112,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Size2'] = {
   0x2A1C: [2030,903,1524,54,1375]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Size2"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size2/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Size3/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Size3/Regular/Main.js
@@ -99,7 +99,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Size3'] = {
   0x2A1C: [2598,1156,1894,54,1745]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Size3"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size3/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Size4/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Size4/Regular/Main.js
@@ -38,7 +38,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Size4'] = {
   0x27E7: [1704,852,534,84,504]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Size4"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size4/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Size5/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Size5/Regular/Main.js
@@ -30,7 +30,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Size5'] = {
   0x27C6: [1260,1803,450,53,397]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Size5"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size5/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Size6/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Size6/Regular/Main.js
@@ -73,7 +73,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Size6'] = {
   0xE02F: [486,-55,271,65,272]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Size6"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size6/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Symbols/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Symbols/Regular/Main.js
@@ -226,7 +226,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Symbols'] = {
   0x29FF: [367,-197,678,60,619]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Symbols"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Symbols/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Variants/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Asana-Math/Variants/Regular/Main.js
@@ -86,7 +86,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['AsanaMathJax_Variants'] = {
   0xE23D: [747,112,962,9,948]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"AsanaMathJax_Variants"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Variants/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Alphabets/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Alphabets/Regular/Main.js
@@ -39,7 +39,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Alphabets'] = {
   0xFEFF: [0,0,0,0,0]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Alphabets"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Alphabets/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Arrows/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Arrows/Regular/Main.js
@@ -54,7 +54,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Arrows'] = {
   0x2907: [450,-50,995,80,915]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Arrows"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Arrows/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/DoubleStruck/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/DoubleStruck/Regular/Main.js
@@ -97,7 +97,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_DoubleStruck'] 
   0x1D7E1: [681,19,680,80,600]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_DoubleStruck"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/DoubleStruck/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Fraktur/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Fraktur/Regular/Main.js
@@ -127,7 +127,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Fraktur'] = {
   0x1D59F: [472,215,461,-8,377]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Fraktur"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Fraktur/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Latin/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Latin/Regular/Main.js
@@ -295,7 +295,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Latin'] = {
   0xFB04: [728,3,900,23,880]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Latin"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Latin/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Main/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Main/Regular/Main.js
@@ -530,7 +530,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Main'] = {
   0x2AB0: [668,158,785,80,705]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Main"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Main/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Marks/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Marks/Regular/Main.js
@@ -101,7 +101,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Marks'] = {
   0x3017: [670,170,474,80,394]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Marks"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Marks/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Misc/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Misc/Regular/Main.js
@@ -34,7 +34,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Misc'] = {
   0x27A1: [450,-50,995,80,915]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Misc"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Misc/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Monospace/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Monospace/Regular/Main.js
@@ -87,7 +87,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Monospace'] = {
   0x1D7FF: [623,12,350,32,317]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Monospace"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Monospace/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/NonUnicode/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/NonUnicode/Regular/Main.js
@@ -1468,7 +1468,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_NonUnicode'] = 
   0xE5A2: [1701,1201,823,80,783]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_NonUnicode"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/NonUnicode/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Normal/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Normal/Regular/Main.js
@@ -367,7 +367,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Normal'] = {
   0x1D7D7: [660,17,500,31,463]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Normal"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Normal/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Operators/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Operators/Regular/Main.js
@@ -108,7 +108,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Operators'] = {
   0x2A2F: [490,-10,641,80,561]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Operators"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Operators/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/SansSerif/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/SansSerif/Regular/Main.js
@@ -369,7 +369,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_SansSerif'] = {
   0x1D7F5: [682,13,637,52,574]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_SansSerif"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/SansSerif/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Script/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Script/Regular/Main.js
@@ -129,7 +129,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Script'] = {
   0x1D503: [408,10,437,-16,494]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Script"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Script/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Shapes/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Shapes/Regular/Main.js
@@ -64,7 +64,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Shapes'] = {
   0x2B33: [400,-100,1370,80,1290]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Shapes"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Shapes/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Size1/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Size1/Regular/Main.js
@@ -201,7 +201,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Size1'] = {
   0x2B31: [740,240,1370,80,1290]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Size1"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size1/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Size2/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Size2/Regular/Main.js
@@ -72,7 +72,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Size2'] = {
   0x27EF: [840,340,365,85,238]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Size2"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size2/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Size3/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Size3/Regular/Main.js
@@ -72,7 +72,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Size3'] = {
   0x27EF: [955,455,381,87,250]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Size3"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size3/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Size4/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Size4/Regular/Main.js
@@ -72,7 +72,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Size4'] = {
   0x27EF: [1093,593,399,90,264]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Size4"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size4/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Size5/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Size5/Regular/Main.js
@@ -72,7 +72,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Size5'] = {
   0x27EF: [1259,759,418,93,279]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Size5"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size5/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Size6/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Size6/Regular/Main.js
@@ -392,7 +392,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Size6'] = {
   0xE13F: [1161,0,1566,80,1238]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Size6"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size6/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Symbols/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Symbols/Regular/Main.js
@@ -77,7 +77,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Symbols'] = {
   0x27EB: [658,158,611,80,531]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Symbols"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Symbols/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Variants/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Pagella/Variants/Regular/Main.js
@@ -32,7 +32,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyrePagellaMathJax_Variants'] = {
   0x2057: [518,-102,1067,65,1002]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyrePagellaMathJax_Variants"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Variants/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Alphabets/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Alphabets/Regular/Main.js
@@ -39,7 +39,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Alphabets'] = {
   0xFEFF: [0,0,0,0,0]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Alphabets"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Alphabets/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Arrows/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Arrows/Regular/Main.js
@@ -54,7 +54,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Arrows'] = {
   0x2907: [470,-30,1030,80,950]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Arrows"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Arrows/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/DoubleStruck/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/DoubleStruck/Regular/Main.js
@@ -97,7 +97,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_DoubleStruck'] =
   0x1D7E1: [716,21,672,80,592]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_DoubleStruck"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/DoubleStruck/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Fraktur/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Fraktur/Regular/Main.js
@@ -127,7 +127,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Fraktur'] = {
   0x1D59F: [461,170,403,80,323]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Fraktur"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Fraktur/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Latin/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Latin/Regular/Main.js
@@ -295,7 +295,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Latin'] = {
   0xFB04: [683,0,827,31,792]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Latin"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Latin/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Main/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Main/Regular/Main.js
@@ -530,7 +530,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Main'] = {
   0x2AB0: [604,94,682,80,602]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Main"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Main/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Marks/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Marks/Regular/Main.js
@@ -101,7 +101,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Marks'] = {
   0x3017: [668,168,430,80,350]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Marks"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Marks/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Misc/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Misc/Regular/Main.js
@@ -34,7 +34,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Misc'] = {
   0x27A1: [470,-30,1030,80,950]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Misc"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Misc/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Monospace/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Monospace/Regular/Main.js
@@ -87,7 +87,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Monospace'] = {
   0x1D7FF: [618,15,600,136,510]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Monospace"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Monospace/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/NonUnicode/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/NonUnicode/Regular/Main.js
@@ -1471,7 +1471,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_NonUnicode'] = {
   0xE5A5: [1161,0,2225,334,2145]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_NonUnicode"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/NonUnicode/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Normal/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Normal/Regular/Main.js
@@ -367,7 +367,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Normal'] = {
   0x1D7D7: [688,13,500,26,473]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Normal"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Normal/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Operators/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Operators/Regular/Main.js
@@ -108,7 +108,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Operators'] = {
   0x2A2F: [455,-45,570,80,490]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Operators"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Operators/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/SansSerif/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/SansSerif/Regular/Main.js
@@ -369,7 +369,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_SansSerif'] = {
   0x1D7F5: [666,8,507,28,467]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_SansSerif"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/SansSerif/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Script/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Script/Regular/Main.js
@@ -129,7 +129,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Script'] = {
   0x1D503: [425,14,716,80,636]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Script"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Script/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Shapes/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Shapes/Regular/Main.js
@@ -64,7 +64,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Shapes'] = {
   0x2B33: [430,-70,1170,80,1090]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Shapes"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Shapes/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Size1/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Size1/Regular/Main.js
@@ -201,7 +201,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Size1'] = {
   0x2B31: [830,330,1170,80,1090]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Size1"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size1/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Size2/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Size2/Regular/Main.js
@@ -72,7 +72,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Size2'] = {
   0x27EF: [833,333,347,85,220]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Size2"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size2/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Size3/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Size3/Regular/Main.js
@@ -72,7 +72,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Size3'] = {
   0x27EF: [948,448,363,87,232]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Size3"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size3/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Size4/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Size4/Regular/Main.js
@@ -72,7 +72,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Size4'] = {
   0x27EF: [1086,586,382,90,247]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Size4"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size4/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Size5/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Size5/Regular/Main.js
@@ -72,7 +72,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Size5'] = {
   0x27EF: [1252,752,399,93,260]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Size5"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size5/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Size6/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Size6/Regular/Main.js
@@ -389,7 +389,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Size6'] = {
   0xE13C: [1161,0,1750,80,1416]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Size6"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size6/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Symbols/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Symbols/Regular/Main.js
@@ -77,7 +77,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Symbols'] = {
   0x27EB: [656,156,543,80,463]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Symbols"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Symbols/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Variants/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Gyre-Termes/Variants/Regular/Main.js
@@ -32,7 +32,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['GyreTermesMathJax_Variants'] = {
   0x2057: [596,-150,1124,66,1058]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"GyreTermesMathJax_Variants"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Variants/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Alphabets/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Alphabets/Regular/Main.js
@@ -38,7 +38,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Alphabets'] = {
   0xFEFF: [0,0,0,0,0]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Alphabets"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Alphabets/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Arrows/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Arrows/Regular/Main.js
@@ -54,7 +54,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Arrows'] = {
   0x2907: [520,20,991,56,935]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Arrows"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Arrows/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/DoubleStruck/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/DoubleStruck/Regular/Main.js
@@ -97,7 +97,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_DoubleStruck'] 
   0x1D7E1: [666,22,556,55,499]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_DoubleStruck"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/DoubleStruck/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Fraktur/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Fraktur/Regular/Main.js
@@ -127,7 +127,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Fraktur'] = {
   0x1D59F: [472,215,461,-8,377]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Fraktur"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Fraktur/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Latin/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Latin/Regular/Main.js
@@ -293,7 +293,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Latin'] = {
   0xFB04: [705,0,833,27,804]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Latin"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Latin/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Main/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Main/Regular/Main.js
@@ -530,7 +530,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Main'] = {
   0x2AB0: [631,119,778,76,702]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Main"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Main/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Marks/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Marks/Regular/Main.js
@@ -101,7 +101,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Marks'] = {
   0x3017: [770,270,458,57,402]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Marks"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Marks/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Misc/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Misc/Regular/Main.js
@@ -29,7 +29,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Misc'] = {
   0x27A1: [468,-31,977,56,921]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Misc"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Misc/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Monospace/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Monospace/Regular/Main.js
@@ -87,7 +87,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Monospace'] = {
   0x1D7FF: [622,11,525,53,471]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Monospace"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Monospace/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/NonUnicode/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/NonUnicode/Regular/Main.js
@@ -2058,7 +2058,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_NonUnicode'] = 
   0xE7F0: [705,19,1142,96,1082]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_NonUnicode"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/NonUnicode/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Normal/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Normal/Regular/Main.js
@@ -367,7 +367,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Normal'] = {
   0x1D7D7: [655,11,575,48,526]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Normal"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Normal/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Operators/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Operators/Regular/Main.js
@@ -108,7 +108,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Operators'] = {
   0x2A2F: [496,-3,778,142,636]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Operators"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Operators/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/SansSerif/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/SansSerif/Regular/Main.js
@@ -369,7 +369,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_SansSerif'] = {
   0x1D7F5: [716,22,550,46,503]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_SansSerif"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/SansSerif/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Script/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Script/Regular/Main.js
@@ -77,7 +77,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Script'] = {
   0x1D4E9: [705,14,800,40,760]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Script"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Script/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Shapes/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Shapes/Regular/Main.js
@@ -64,7 +64,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Shapes'] = {
   0x2B33: [510,10,1463,56,1407]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Shapes"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Shapes/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size1/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size1/Regular/Main.js
@@ -200,7 +200,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Size1'] = {
   0x2B31: [990,490,1463,56,1407]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Size1"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size1/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size2/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size2/Regular/Main.js
@@ -72,7 +72,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Size2'] = {
   0x27EF: [864,364,323,56,205]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Size2"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size2/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size3/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size3/Regular/Main.js
@@ -72,7 +72,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Size3'] = {
   0x27EF: [991,491,370,56,228]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Size3"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size3/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size4/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size4/Regular/Main.js
@@ -72,7 +72,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Size4'] = {
   0x27EF: [1168,668,432,56,256]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Size4"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size4/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size5/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size5/Regular/Main.js
@@ -71,7 +71,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Size5'] = {
   0x27EF: [1320,820,485,56,279]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Size5"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size5/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size6/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size6/Regular/Main.js
@@ -71,7 +71,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Size6'] = {
   0x27EF: [1472,972,541,56,306]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Size6"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size6/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size7/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Size7/Regular/Main.js
@@ -380,7 +380,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Size7'] = {
   0xE134: [620,0,1056,702,1076]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Size7"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size7/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Symbols/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Symbols/Regular/Main.js
@@ -76,7 +76,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Symbols'] = {
   0x27EB: [750,250,570,53,460]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Symbols"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Symbols/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Variants/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Latin-Modern/Variants/Regular/Main.js
@@ -32,7 +32,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['LatinModernMathJax_Variants'] = {
   0x2057: [549,-96,1127,67,1060]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"LatinModernMathJax_Variants"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Variants/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Alphabets/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Alphabets/Regular/Main.js
@@ -26,7 +26,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Alphabets'] = {
   0x2126: [689,2,875,25,844]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Alphabets"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Alphabets/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Arrows/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Arrows/Regular/Main.js
@@ -29,7 +29,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Arrows'] = {
   0x27FE: [598,98,1700,75,1643]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Arrows"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Arrows/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Fraktur/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Fraktur/Regular/Main.js
@@ -127,7 +127,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Fraktur'] = {
   0x1D59F: [472,215,461,-8,377]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Fraktur"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Fraktur/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Main/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Main/Regular/Main.js
@@ -344,7 +344,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Main'] = {
   0x27FC: [500,0,1690,56,1634]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Main"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Main/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Marks/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Marks/Regular/Main.js
@@ -45,7 +45,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Marks'] = {
   0x20EF: [50,221,287,0,418]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Marks"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Marks/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/NonUnicode/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/NonUnicode/Regular/Main.js
@@ -1108,7 +1108,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_NonUnicode'] = {
   0xE43A: [588,-1,1123,70,1053]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_NonUnicode"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/NonUnicode/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Normal/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Normal/Regular/Main.js
@@ -142,7 +142,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Normal'] = {
   0x1D7D7: [707,10,550,48,514]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Normal"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Normal/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Operators/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Operators/Regular/Main.js
@@ -62,7 +62,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Operators'] = {
   0x2A0C: [950,161,1456,49,1407]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Operators"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Operators/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Script/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Script/Regular/Main.js
@@ -77,7 +77,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Script'] = {
   0x1D4E9: [705,14,742,57,714]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Script"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Script/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Shapes/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Shapes/Regular/Main.js
@@ -26,7 +26,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Shapes'] = {
   0x2B1A: [690,6,816,60,756]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Shapes"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Shapes/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Size1/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Size1/Regular/Main.js
@@ -72,7 +72,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Size1'] = {
   0x2A0C: [2022,200,1433,41,1507]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Size1"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size1/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Size2/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Size2/Regular/Main.js
@@ -61,7 +61,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Size2'] = {
   0x27E9: [939,237,568,79,375]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Size2"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size2/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Size3/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Size3/Regular/Main.js
@@ -52,7 +52,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Size3'] = {
   0x27E9: [1536,234,693,89,500]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Size3"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size3/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Size4/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Size4/Regular/Main.js
@@ -52,7 +52,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Size4'] = {
   0x27E9: [2134,232,818,100,625]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Size4"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size4/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Size5/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Size5/Regular/Main.js
@@ -51,7 +51,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Size5'] = {
   0xE016: [120,202,450,-10,474]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Size5"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size5/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Symbols/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Symbols/Regular/Main.js
@@ -49,7 +49,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Symbols'] = {
   0x23AE: [381,0,444,181,265]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Symbols"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Symbols/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Variants/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/Neo-Euler/Variants/Regular/Main.js
@@ -42,7 +42,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['NeoEulerMathJax_Variants'] = {
   0xE209: [470,182,501,27,468]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"NeoEulerMathJax_Variants"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Variants/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Alphabets/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Alphabets/Bold/Main.js
@@ -199,7 +199,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Alphabets-bold'] = {
   0xE400: [691,203,556,14,487]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Alphabets-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Alphabets/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Alphabets/BoldItalic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Alphabets/BoldItalic/Main.js
@@ -204,7 +204,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Alphabets-bold-italic'
   0xE400: [703,205,556,-188,517]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Alphabets-bold-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Alphabets/BoldItalic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Alphabets/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Alphabets/Italic/Main.js
@@ -201,7 +201,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Alphabets-italic'] = {
   0xE400: [681,207,500,-141,504]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Alphabets-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Alphabets/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Alphabets/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Alphabets/Regular/Main.js
@@ -213,7 +213,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Alphabets'] = {
   0xE400: [683,218,541,32,457]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Alphabets"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Alphabets/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Arrows/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Arrows/Bold/Main.js
@@ -56,7 +56,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Arrows-bold'] = {
   0xE0B6: [478,-56,0,15,142]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Arrows-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Arrows/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Arrows/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Arrows/Regular/Main.js
@@ -243,7 +243,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Arrows'] = {
   0xE137: [405,-101,1033,229,805]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Arrows"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Arrows/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/DoubleStruck/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/DoubleStruck/Bold/Main.js
@@ -83,7 +83,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_DoubleStruck-bold'] = 
   0x1D56B: [461,0,513,40,473]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_DoubleStruck-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/DoubleStruck/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/DoubleStruck/BoldItalic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/DoubleStruck/BoldItalic/Main.js
@@ -41,7 +41,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_DoubleStruck-bold-ital
   0x2149: [669,205,421,-93,455]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_DoubleStruck-bold-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/DoubleStruck/BoldItalic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/DoubleStruck/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/DoubleStruck/Italic/Main.js
@@ -40,7 +40,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_DoubleStruck-italic'] 
   0x2149: [653,217,341,-104,394]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_DoubleStruck-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/DoubleStruck/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/DoubleStruck/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/DoubleStruck/Regular/Main.js
@@ -92,7 +92,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_DoubleStruck'] = {
   0x1D7E1: [676,12,540,28,512]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_DoubleStruck"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/DoubleStruck/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Fraktur/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Fraktur/Bold/Main.js
@@ -81,7 +81,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Fraktur-bold'] = {
   0x1D59F: [475,219,484,36,437]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Fraktur-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Fraktur/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Fraktur/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Fraktur/Regular/Main.js
@@ -75,7 +75,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Fraktur'] = {
   0x1D537: [468,209,457,43,407]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Fraktur"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Fraktur/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Latin/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Latin/Bold/Main.js
@@ -277,7 +277,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Latin-bold'] = {
   0xFB04: [691,0,833,15,812]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Latin-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Latin/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Latin/BoldItalic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Latin/BoldItalic/Main.js
@@ -277,7 +277,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Latin-bold-italic'] = 
   0xFB04: [704,205,854,-169,851]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Latin-bold-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Latin/BoldItalic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Latin/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Latin/Italic/Main.js
@@ -276,7 +276,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Latin-italic'] = {
   0xFB04: [682,207,745,-147,763]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Latin-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Latin/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Latin/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Latin/Regular/Main.js
@@ -282,7 +282,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Latin'] = {
   0xFB04: [683,0,830,20,796]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Latin"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Latin/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Main/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Main/Bold/Main.js
@@ -504,7 +504,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Main-bold'] = {
   0x2AC6: [730,222,750,80,670]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Main-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Main/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Main/BoldItalic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Main/BoldItalic/Main.js
@@ -222,7 +222,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Main-bold-italic'] = {
   0x24C8: [690,19,695,0,695]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Main-bold-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Main/BoldItalic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Main/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Main/Italic/Main.js
@@ -222,7 +222,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Main-italic'] = {
   0x24C8: [676,14,684,0,684]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Main-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Main/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Main/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Main/Regular/Main.js
@@ -571,7 +571,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Main'] = {
   0xFFFD: [662,217,872,55,817]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Main"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Main/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Marks/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Marks/Bold/Main.js
@@ -194,7 +194,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Marks-bold'] = {
   0xE28D: [734,-484,0,92,498]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Marks-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Marks/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Marks/BoldItalic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Marks/BoldItalic/Main.js
@@ -62,7 +62,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Marks-bold-italic'] = 
   0x20DD: [760,254,0,-753,256]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Marks-bold-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Marks/BoldItalic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Marks/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Marks/Italic/Main.js
@@ -79,7 +79,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Marks-italic'] = {
   0x20EF: [-40,252,0,-453,-17]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Marks-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Marks/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Marks/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Marks/Regular/Main.js
@@ -204,7 +204,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Marks'] = {
   0xE28D: [734,-484,0,94,460]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Marks"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Marks/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Misc/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Misc/Bold/Main.js
@@ -196,7 +196,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Misc-bold'] = {
   0x24EA: [690,19,695,0,695]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Misc-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Misc/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Misc/BoldItalic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Misc/BoldItalic/Main.js
@@ -181,7 +181,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Misc-bold-italic'] = {
   0x24EA: [690,19,695,0,695]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Misc-bold-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Misc/BoldItalic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Misc/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Misc/Italic/Main.js
@@ -180,7 +180,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Misc-italic'] = {
   0x24EA: [676,14,684,0,684]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Misc-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Misc/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Misc/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Misc/Regular/Main.js
@@ -268,7 +268,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Misc'] = {
   0xE13A: [943,11,735,67,1302]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Misc"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Misc/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Monospace/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Monospace/Regular/Main.js
@@ -87,7 +87,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Monospace'] = {
   0x1D7FF: [681,11,525,58,464]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Monospace"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Monospace/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Normal/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Normal/Bold/Main.js
@@ -147,7 +147,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Normal-bold'] = {
   0x1D7D7: [688,13,500,26,473]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Normal-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Normal/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Normal/BoldItalic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Normal/BoldItalic/Main.js
@@ -137,7 +137,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Normal-bold-italic'] =
   0x1D755: [449,10,868,33,879]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Normal-bold-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Normal/BoldItalic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Normal/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Normal/Italic/Main.js
@@ -138,7 +138,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Normal-italic'] = {
   0x1D71B: [428,11,856,30,866]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Normal-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Normal/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Operators/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Operators/Bold/Main.js
@@ -172,7 +172,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Operators-bold'] = {
   0xE3C4: [747,243,750,68,683]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Operators-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Operators/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Operators/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Operators/Regular/Main.js
@@ -433,7 +433,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Operators'] = {
   0xE3C4: [627,135,685,48,637]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Operators"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Operators/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/SansSerif/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/SansSerif/Bold/Main.js
@@ -146,7 +146,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_SansSerif-bold'] = {
   0x1D7F5: [688,13,500,26,475]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_SansSerif-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/SansSerif/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/SansSerif/BoldItalic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/SansSerif/BoldItalic/Main.js
@@ -147,7 +147,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_SansSerif-bold-italic'
   0x1D7C9: [462,14,889,40,912]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_SansSerif-bold-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/SansSerif/BoldItalic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/SansSerif/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/SansSerif/Italic/Main.js
@@ -144,7 +144,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_SansSerif-italic'] = {
   0x1D63B: [453,0,447,25,517]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_SansSerif-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/SansSerif/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/SansSerif/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/SansSerif/Regular/Main.js
@@ -143,7 +143,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_SansSerif'] = {
   0x1D7EB: [676,21,500,28,466]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_SansSerif"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/SansSerif/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Script/BoldItalic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Script/BoldItalic/Main.js
@@ -90,7 +90,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Script-bold-italic'] =
   0x1D503: [493,14,782,61,702]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Script-bold-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Script/BoldItalic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Script/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Script/Italic/Main.js
@@ -78,7 +78,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Script-italic'] = {
   0x1D4CF: [478,11,691,52,617]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Script-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Script/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Script/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Script/Regular/Main.js
@@ -77,7 +77,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Script'] = {
   0x1D4CF: [478,11,691,52,617]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Script"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Script/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Shapes/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Shapes/Bold/Main.js
@@ -39,7 +39,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Shapes-bold'] = {
   0xE290: [175,0,633,-1,634]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Shapes-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Shapes/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Shapes/BoldItalic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Shapes/BoldItalic/Main.js
@@ -28,7 +28,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Shapes-bold-italic'] =
   0x2423: [31,120,500,40,460]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Shapes-bold-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Shapes/BoldItalic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Shapes/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Shapes/Regular/Main.js
@@ -312,7 +312,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Shapes'] = {
   0xE3C8: [662,156,902,0,863]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Shapes"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Shapes/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Size1/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Size1/Regular/Main.js
@@ -131,7 +131,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Size1'] = {
   0x2AFF: [867,363,410,100,310]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Size1"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size1/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Size2/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Size2/Regular/Main.js
@@ -83,7 +83,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Size2'] = {
   0x2AFF: [1586,289,636,133,503]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Size2"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size2/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Size3/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Size3/Regular/Main.js
@@ -80,7 +80,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Size3'] = {
   0x2986: [2066,393,1029,115,849]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Size3"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size3/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Size4/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Size4/Regular/Main.js
@@ -77,7 +77,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Size4'] = {
   0x2986: [2566,509,1175,194,1049]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Size4"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size4/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Size5/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Size5/Regular/Main.js
@@ -116,7 +116,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Size5'] = {
   0xE03E: [1086,59,688,115,394]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Size5"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size5/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Symbols/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Symbols/Bold/Main.js
@@ -47,7 +47,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Symbols-bold'] = {
   0x29C7: [661,158,910,45,865]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Symbols-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Symbols/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Symbols/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Symbols/Regular/Main.js
@@ -260,7 +260,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Symbols'] = {
   0xE0D6: [386,-120,750,50,700]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Symbols"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Symbols/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Variants/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Variants/Bold/Main.js
@@ -97,7 +97,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Variants-bold'] = {
   0xE287: [421,202,523,25,499]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Variants-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Variants/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Variants/BoldItalic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Variants/BoldItalic/Main.js
@@ -63,7 +63,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Variants-bold-italic']
   0xE288: [463,217,600,49,539]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Variants-bold-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Variants/BoldItalic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Variants/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Variants/Italic/Main.js
@@ -62,7 +62,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Variants-italic'] = {
   0xE286: [460,217,570,23,526]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Variants-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Variants/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Variants/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX-Web/Variants/Regular/Main.js
@@ -158,7 +158,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['STIXMathJax_Variants'] = {
   0xE285: [421,200,523,41,483]
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"STIXMathJax_Variants"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Variants/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX/fontdata.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX/fontdata.js
@@ -1588,7 +1588,7 @@
   //  Load any patch files and then call loadComplete()
   //
   QUEUE.push(["loadComplete",MathJax.Ajax,HTMLCSS.fontDir + "/fontdata.js"]);
-  MathJax.Callback.Queue.apply(MathJax.Callback,QUEUE);
+  MathJax.CallBack.Queue.apply(MathJax.CallBack,QUEUE);
 
 })(MathJax.OutputJax["HTML-CSS"],MathJax.ElementJax.mml,MathJax.HTML);
 

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/AMS/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/AMS/Regular/Main.js
@@ -46,7 +46,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_AMS'] = {
 
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_AMS"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/AMS/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Caligraphic/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Caligraphic/Bold/Main.js
@@ -91,7 +91,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Caligraphic-bold'] = {
   0xA0: [0,0,250,0,0]                // NO-BREAK SPACE
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Caligraphic-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Caligraphic/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Caligraphic/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Caligraphic/Regular/Main.js
@@ -90,7 +90,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Caligraphic'] = {
   0xA0: [0,0,250,0,0]                // NO-BREAK SPACE
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Caligraphic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Caligraphic/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Fraktur/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Fraktur/Bold/Main.js
@@ -31,7 +31,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Fraktur-bold'] = {
 
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Fraktur-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Fraktur/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Fraktur/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Fraktur/Regular/Main.js
@@ -30,7 +30,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Fraktur'] = {
 
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Fraktur"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Fraktur/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Greek/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Greek/Bold/Main.js
@@ -38,7 +38,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Greek-bold'] = {
   0x3A9: [696,1,831,51,779]          // GREEK CAPITAL LETTER OMEGA
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Greek-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Greek/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Greek/BoldItalic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Greek/BoldItalic/Main.js
@@ -105,7 +105,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Greek-bold-italic'] = {
   0x3F5: [444,7,483,44,450]          // GREEK LUNATE EPSILON SYMBOL
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Greek-bold-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Greek/BoldItalic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Greek/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Greek/Italic/Main.js
@@ -104,7 +104,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Greek-italic'] = {
   0x3F5: [431,11,406,40,382]         // GREEK LUNATE EPSILON SYMBOL
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Greek-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Greek/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Greek/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Greek/Regular/Main.js
@@ -37,7 +37,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Greek'] = {
   0x3A9: [704,0,722,44,677]          // GREEK CAPITAL LETTER OMEGA
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Greek"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Greek/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Main/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Main/Bold/Main.js
@@ -156,7 +156,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Main-bold'] = {
   0x3A9: [696,0,831,51,779]          // GREEK CAPITAL LETTER OMEGA
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Main-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Main/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Main/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Main/Italic/Main.js
@@ -132,7 +132,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Main-italic'] = {
   0x3A9: [705,0,716,100,759]         // GREEK CAPITAL LETTER OMEGA
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Main-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Main/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Main/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Main/Regular/Main.js
@@ -299,7 +299,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Main'] = {
   0x2AB0: [636,138,778,83,694]       // SUCCEEDS ABOVE SINGLE-LINE EQUALS SIGN
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Main"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Main/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Math/BoldItalic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Math/BoldItalic/Main.js
@@ -200,7 +200,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Math-bold-italic'] = {
   0x3F5: [444,7,483,44,450]          // GREEK LUNATE EPSILON SYMBOL
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Math-bold-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Math/BoldItalic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Math/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Math/Italic/Main.js
@@ -199,7 +199,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Math-italic'] = {
   0x3F5: [431,11,406,40,382]         // GREEK LUNATE EPSILON SYMBOL
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Math-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Math/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/SansSerif/Bold/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/SansSerif/Bold/Main.js
@@ -31,7 +31,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_SansSerif-bold'] = {
 
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_SansSerif-bold"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/SansSerif/Bold/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/SansSerif/Italic/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/SansSerif/Italic/Main.js
@@ -31,7 +31,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_SansSerif-italic'] = {
 
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_SansSerif-italic"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/SansSerif/Italic/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/SansSerif/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/SansSerif/Regular/Main.js
@@ -30,7 +30,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_SansSerif'] = {
 
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_SansSerif"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/SansSerif/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Script/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Script/Regular/Main.js
@@ -57,7 +57,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Script'] = {
 
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Script"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Script/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Size1/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Size1/Regular/Main.js
@@ -69,7 +69,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Size1'] = {
   0x2A06: [750,249,833,55,777]       // N-ARY SQUARE UNION OPERATOR
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Size1"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size1/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Size2/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Size2/Regular/Main.js
@@ -61,7 +61,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Size2'] = {
   0x2A06: [950,450,1111,55,1055]     // N-ARY SQUARE UNION OPERATOR
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Size2"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size2/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Size3/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Size3/Regular/Main.js
@@ -45,7 +45,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Size3'] = {
   0x27E9: [1450,949,750,94,623]      // MATHEMATICAL RIGHT ANGLE BRACKET
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Size3"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size3/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Size4/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Size4/Regular/Main.js
@@ -72,7 +72,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Size4'] = {
   0xE154: [120,0,400,-10,410]        // stix-oblique open face capital letter A
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Size4"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Size4/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/Typewriter/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/Typewriter/Regular/Main.js
@@ -30,7 +30,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_Typewriter'] = {
 
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_Typewriter"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/Typewriter/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/WinChrome/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/WinChrome/Regular/Main.js
@@ -38,7 +38,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_WinChrome'] = {
   0xE2F1: [587,85,894,96,797]        // stix-lowercase u bold italic slashed
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_WinChrome"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/WinChrome/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/WinIE6/Regular/Main.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/WinIE6/Regular/Main.js
@@ -106,7 +106,7 @@ MathJax.OutputJax['HTML-CSS'].FONTDATA.FONTS['MathJax_WinIE6'] = {
   0xE2B2: [40,2960,1000,111,1020]    // stix-capital P italic slashed
 };
 
-MathJax.Callback.Queue(
+MathJax.CallBack.Queue(
   ["initFont",MathJax.OutputJax["HTML-CSS"],"MathJax_WinIE6"],
   ["loadComplete",MathJax.Ajax,MathJax.OutputJax["HTML-CSS"].fontDir+"/WinIE6/Regular/Main.js"]
 );

--- a/unpacked/jax/output/HTML-CSS/imageFonts.js
+++ b/unpacked/jax/output/HTML-CSS/imageFonts.js
@@ -188,7 +188,7 @@
     
     var IMGDIR = HTMLCSS.imgDir + HTMLCSS.imgPacked;
     
-    MathJax.Callback.Queue(
+    MathJax.CallBack.Queue(
       ["Require",AJAX,IMGDIR+"/imagedata.js"],
       GETWIDTHS,
       ["loadComplete",AJAX,HTMLCSS.directory+"/imageFonts.js"]

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -177,8 +177,8 @@
     loadWebFont: function (font) {
       HUB.Startup.signal.Post("HTML-CSS Jax - Web-Font "+HTMLCSS.fontInUse+"/"+font.directory);
       var n = MESSAGE(["LoadWebFont","Loading web-font %1",HTMLCSS.fontInUse+"/"+font.directory]);
-      var done = MathJax.Callback({}); // called when font is loaded
-      var callback = MathJax.Callback(["loadComplete",this,font,n,done]);
+      var done = MathJax.CallBack({}); // called when font is loaded
+      var callback = MathJax.CallBack(["loadComplete",this,font,n,done]);
       AJAX.timer.start(AJAX,[this.checkWebFont,font,callback],0,this.timeout);
       return done;
     },
@@ -518,7 +518,7 @@
       //  arrived yet, so try to wait for it, but don't wait too long.
       //
       if (this.defaultEm) return;
-      var ready = MathJax.Callback();
+      var ready = MathJax.CallBack();
       AJAX.timer.start(AJAX,function (check) {
         if (check.time(ready)) {HUB.signal.Post("HTML-CSS Jax - no default em size"); return}
         HTMLCSS.getDefaultExEm();
@@ -650,7 +650,7 @@
       //  
       if (state.HTMLCSSdelay) {
         state.HTMLCSSdelay = false;
-        HUB.RestartAfter(MathJax.Callback.Delay(this.config.EqnChunkDelay));
+        HUB.RestartAfter(MathJax.CallBack.Delay(this.config.EqnChunkDelay));
       }
 
       //
@@ -1585,7 +1585,7 @@
     },
 
     loadFont: function (file) {
-      var queue = MathJax.Callback.Queue();
+      var queue = MathJax.CallBack.Queue();
       queue.Push(["Require",AJAX,this.fontDir+"/"+file]);
       if (this.imgFonts) {
         if (!MathJax.isPacked) {file = file.replace(/\/([^\/]*)$/,HTMLCSS.imgPacked+"/$1")}
@@ -2879,7 +2879,7 @@
     //  will call Config and Startup, which need to modify the body.
     //
     MathJax.Hub.Register.StartupHook("onLoad",function () {
-      setTimeout(MathJax.Callback(["loadComplete",HTMLCSS,"jax.js"]),0);
+      setTimeout(MathJax.CallBack(["loadComplete",HTMLCSS,"jax.js"]),0);
     });
   });
 

--- a/unpacked/jax/output/NativeMML/jax.js
+++ b/unpacked/jax/output/NativeMML/jax.js
@@ -1309,7 +1309,7 @@
     //  (it would call NativeMML's Require routine, asking for the mml jax again)
     //  so wait until after the mml jax has finished processing.
     //
-    setTimeout(MathJax.Callback(["loadComplete",nMML,"jax.js"]),0);
+    setTimeout(MathJax.CallBack(["loadComplete",nMML,"jax.js"]),0);
   });
   
 

--- a/unpacked/jax/output/SVG/autoload/maction.js
+++ b/unpacked/jax/output/SVG/autoload/maction.js
@@ -71,18 +71,18 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       toggle: function (svg,frame,selection) {
         this.selection = selection;
         SVG.Element(frame,{cursor:"pointer"});
-        frame.onclick = MathJax.Callback(["SVGclick",this]);
+        frame.onclick = MathJax.CallBack(["SVGclick",this]);
       },
       
       statusline: function (svg,frame,selection) {
-        frame.onmouseover = MathJax.Callback(["SVGsetStatus",this]),
-        frame.onmouseout  = MathJax.Callback(["SVGclearStatus",this]);
+        frame.onmouseover = MathJax.CallBack(["SVGsetStatus",this]),
+        frame.onmouseout  = MathJax.CallBack(["SVGclearStatus",this]);
         frame.onmouseover.autoReset = frame.onmouseout.autoReset = true;
       },
       
       tooltip: function(svg,frame,selection) {
-        frame.onmouseover = MathJax.Callback(["SVGtooltipOver",this]),
-        frame.onmouseout  = MathJax.Callback(["SVGtooltipOut",this]);
+        frame.onmouseover = MathJax.CallBack(["SVGtooltipOver",this]),
+        frame.onmouseout  = MathJax.CallBack(["SVGtooltipOut",this]);
         frame.onmouseover.autoReset = frame.onmouseout.autoReset = true;
       }
     },
@@ -132,13 +132,13 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
         x = event.clientX + document.body.scrollLeft + document.documentElement.scrollLeft;
         y = event.clientY + document.body.scrollTop + document.documentElement.scrollTop;
       }
-      var callback = MathJax.Callback(["SVGtooltipPost",this,x+CONFIG.offsetX,y+CONFIG.offsetY])
+      var callback = MathJax.CallBack(["SVGtooltipPost",this,x+CONFIG.offsetX,y+CONFIG.offsetY])
       hover = setTimeout(callback,CONFIG.delayPost);
     },
     SVGtooltipOut: function (event) {
       if (hover) {clearTimeout(hover); hover = null}
       if (clear) {clearTimeout(clear)}
-      var callback = MathJax.Callback(["SVGtooltipClear",this,80]);
+      var callback = MathJax.CallBack(["SVGtooltipClear",this,80]);
       clear = setTimeout(callback,CONFIG.delayClear);
     },
     SVGtooltipPost: function (x,y) {
@@ -171,7 +171,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       try {math.toSVG(span,tip)} catch(err) {
         this.SetData(1,mml); tip.style.display = "none";
         if (!err.restart) {throw err}
-        MathJax.Callback.After(["SVGtooltipPost",this,x,y],err.restart);
+        MathJax.CallBack.After(["SVGtooltipPost",this,x,y],err.restart);
         return;
       }
       this.SetData(1,mml);
@@ -186,7 +186,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
         clear = null;
       } else {
         tip.style.opacity = n/100;
-        clear = setTimeout(MathJax.Callback(["SVGtooltipClear",this,n-20]),50);
+        clear = setTimeout(MathJax.CallBack(["SVGtooltipClear",this,n-20]),50);
       }
     }
   });

--- a/unpacked/jax/output/SVG/autoload/mglyph.js
+++ b/unpacked/jax/output/SVG/autoload/mglyph.js
@@ -69,8 +69,8 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
         if (!this.img) {
           this.img = MML.mglyph.GLYPH[values.src] = {img: new Image(), status: "pending"};
           img = this.img.img;
-          img.onload  = MathJax.Callback(["SVGimgLoaded",this]);
-          img.onerror = MathJax.Callback(["SVGimgError",this]);
+          img.onload  = MathJax.CallBack(["SVGimgLoaded",this]);
+          img.onerror = MathJax.CallBack(["SVGimgError",this]);
           img.src = values.src;
           MathJax.Hub.RestartAfter(img.onload);
         }

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -290,7 +290,7 @@
       //  
       if (state.SVGdelay) {
         state.SVGdelay = false;
-        HUB.RestartAfter(MathJax.Callback.Delay(this.config.EqnChunkDelay));
+        HUB.RestartAfter(MathJax.CallBack.Delay(this.config.EqnChunkDelay));
       }
 
       //
@@ -2092,7 +2092,7 @@
     //  will call Config and Startup, which need to modify the body.
     //
     HUB.Register.StartupHook("onLoad",function () {
-      setTimeout(MathJax.Callback(["loadComplete",SVG,"jax.js"]),0);
+      setTimeout(MathJax.CallBack(["loadComplete",SVG,"jax.js"]),0);
     });
   });
 


### PR DESCRIPTION
I noticed that callbacks had two names and reading the documentation I assumed CallBack is the preferred one (or newer?). Anyway this normalises the two names to the camel case CallBack. This only changes the unpacked sources because I didn't find the info on how to build the packed version. The only test I ran was by changing `test/index.html` to load the unpacked sources and it went fine.
