### PR TITLE
fixes #863

### DIFF
--- a/unpacked/extensions/mml2jax.js
+++ b/unpacked/extensions/mml2jax.js
@@ -206,7 +206,7 @@ MathJax.Extension.mml2jax = {
     if (preview === "mathml") {
       isNodePreview = true;
       // mathml preview does not work with IE < 9, so fallback to alttext.
-      if (this.MathTagBug) {preview = "alttext"} else {preview = math.cloneNode(false)}
+      if (this.MathTagBug) {preview = "alttext"} else {preview = math.cloneNode(true)}
     }
     if (preview === "alttext" || preview === "altimg") {
       isNodePreview = true;


### PR DESCRIPTION
math.cloneNode set to true to leave the original MathML as preview
