### PR TITLE
remove version number from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "MathJax",
-  "version": "2.3.0",
   "main": "./MathJax.js",
   "homepage": "http://www.mathjax.org/",
   "ignore": [


### PR DESCRIPTION
Bower ignores the version number anyway; this avoids confusion. Fixes #816. 
