### PR TITLE
UNTESTED: Include stack trace in [Math Processing Error]->menu->show as error message

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -2327,12 +2327,13 @@ MathJax.Hub = {
   
   formatError: function (script,err) {
     //
-    //  Get the error message, URL, and line, and save it for
+    //  Get the error message, URL, line, and stack trace, and save it for
     //    reporting in the Show Math As Error menu
     //
     var message = "Error: "+err.message+"\n";
     if (err.sourceURL) {message += "\nfile: "+err.sourceURL}
     if (err.line) {message += "\nline: "+err.line}
+    if (err.stack) {message += "\nstack:\n"+err.stack}
     script.MathJax.error = MathJax.OutputJax.Error.Jax(message,script);
 
     //


### PR DESCRIPTION
If I see a [Math Processing Error], its error message is something non-informative like
`Error: Cannot read property 'firstChild' of null`.
This (or something similar) would help a lot — if not me than you after I file a better bug report :-)
[will file separately for the actual errors that prompted this]

*PLEASE TEST*.
I only tried this on Chrome and Firefox (Linux) and didn't run any test suite.
The `if(err.stack)` test sounds safe to me (and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack claims wide support) but I'm the kind of web dev who breaks stuff in prod and doesn't notice for months...