### PR TITLE
Update MathZoom.js with global border-box support

### DIFF
--- a/unpacked/extensions/MathZoom.js
+++ b/unpacked/extensions/MathZoom.js
@@ -40,6 +40,9 @@
         "text-align":"left", "text-indent":0, "text-transform":"none",
         "line-height":"normal", "letter-spacing":"normal", "word-spacing":"normal",
         "word-wrap":"normal", "white-space":"nowrap", "float":"none",
+        "-webkit-box-sizing":"content-box",          // Android ≤ 2.3, iOS ≤ 4
+        "-moz-box-sizing":"content-box",             // Firefox ≤ 28
+        "box-sizing":"content-box",                  // Chrome, Firefox 29+, IE 8+, Opera, Safari 5.1
         "box-shadow":"5px 5px 15px #AAAAAA",         // Opera 10.5 and IE9
         "-webkit-box-shadow":"5px 5px 15px #AAAAAA", // Safari 3 and Chrome
         "-moz-box-shadow":"5px 5px 15px #AAAAAA",    // Forefox 3.5


### PR DESCRIPTION
With a lot of sites using the global box-sizing it breaks the zoom box on large equations when the zoom goes wider than the screen.  This fix will explicitly add content-box on this element to prevent a global override.