### PR TITLE
Since we probably can't give informative traceback, tell user how to obtain one.

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -2333,6 +2333,7 @@ MathJax.Hub = {
     var message = "Error: "+err.message+"\n";
     if (err.sourceURL) {message += "\nfile: "+err.sourceURL}
     if (err.line) {message += "\nline: "+err.line}
+    message += "\n[debugging tips: use unpacked/MathJax.js, inspect `MathJax.Hub.lastError` in the console]";
     script.MathJax.error = MathJax.OutputJax.Error.Jax(message,script);
 
     //


### PR DESCRIPTION
Instead of #1184.
I think both points are non-obvious good leads for people who don't debug MathJax every day.