### PR TITLE
A few menu display tweaks

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -1048,10 +1048,11 @@ MathJax.HTML = {
           {def.style[id.replace(/-([a-z])/g,this.ucMatch)] = style[id]}}
       }
       MathJax.Hub.Insert(obj,def);
+      for (var id in def) {if (id.substr(0,5) === "aria-") obj.setAttribute(id,def[id])}
     }
     if (contents) {
       if (!(contents instanceof Array)) {contents = [contents]}
-      for (var i = 0; i < contents.length; i++) {
+      for (var i = 0, m = contents.length; i < m; i++) {
         if (contents[i] instanceof Array) {
           obj.appendChild(this.Element(contents[i][0],contents[i][1],contents[i][2]));
         } else if (type === "script") { // IE throws an error if script is added as a text node

--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -2354,18 +2354,26 @@ MathJax.Hub = {
     //
     var errorSettings = this.config.errorSettings;
     var errorText = LOCALIZE(errorSettings.messageId,errorSettings.message);
-    var error = MathJax.HTML.Element("span",
-                 {className:"MathJax_Error", jaxID:"Error", isMathJax:true},errorText);
+    var error = MathJax.HTML.Element("span", {
+      className:"MathJax_Error", jaxID:"Error", isMathJax:true,
+      id: script.MathJax.error.inputID+"-Frame"
+    },errorText);
     //
     //  Attach the menu events
     //
     if (MathJax.Extension.MathEvents) {
-      error.oncontextmenu = MathJax.Extension.MathEvents.Event.Menu;
-      error.onmousedown = MathJax.Extension.MathEvents.Event.Mousedown;
+      var EVENT = MathJax.Extension.MathEvents.Event;
+      error.oncontextmenu = EVENT.Menu;
+      error.onmousedown = EVENT.Mousedown;
+      error.onkeydown = EVENT.Keydown;
+      error.tabIndex = 0;
     } else {
       MathJax.Ajax.Require("[MathJax]/extensions/MathEvents.js",function () {
-        error.oncontextmenu = MathJax.Extension.MathEvents.Event.Menu;
-        error.onmousedown = MathJax.Extension.MathEvents.Event.Mousedown;
+        var EVENT = MathJax.Extension.MathEvents.Event;
+        error.oncontextmenu = EVENT.Menu;
+        error.onmousedown = EVENT.Mousedown;
+        error.keydown = EVENT.Keydown;
+        error.tabIndex = 0;
       });
     }
     //
@@ -3036,15 +3044,17 @@ MathJax.Hub.Startup = {
   //  Some "Fake" jax used to allow menu access for "Math Processing Error" messages
   //
   BASE.OutputJax.Error = {
-    id: "Error", version: "2.5.0", config: {},
+    id: "Error", version: "2.5.0", config: {}, errors: 0,
     ContextMenu: function () {return BASE.Extension.MathEvents.Event.ContextMenu.apply(BASE.Extension.MathEvents.Event,arguments)},
     Mousedown:   function () {return BASE.Extension.MathEvents.Event.AltContextMenu.apply(BASE.Extension.MathEvents.Event,arguments)},
     getJaxFromMath: function (math) {return (math.nextSibling.MathJax||{}).error},
     Jax: function (text,script) {
       var jax = MathJax.Hub.inputJax[script.type.replace(/ *;(.|\s)*/,"")];
+      this.errors++;
       return {
         inputJax: (jax||{id:"Error"}).id,  // Use Error InputJax as fallback
         outputJax: "Error",
+        inputID: "MathJax-Error-"+this.errors,
         sourceMenuTitle: /*_(MathMenu)*/ ["ErrorMessage","Error Message"],
         sourceMenuFormat: "Error",
         originalText: MathJax.HTML.getScript(script),

--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -1048,7 +1048,9 @@ MathJax.HTML = {
           {def.style[id.replace(/-([a-z])/g,this.ucMatch)] = style[id]}}
       }
       MathJax.Hub.Insert(obj,def);
-      for (var id in def) {if (id.substr(0,5) === "aria-") obj.setAttribute(id,def[id])}
+      for (var id in def) {
+        if (id === "role" || id.substr(0,5) === "aria-") obj.setAttribute(id,def[id]);
+      }
     }
     if (contents) {
       if (!(contents instanceof Array)) {contents = [contents]}

--- a/unpacked/extensions/HelpDialog.js
+++ b/unpacked/extensions/HelpDialog.js
@@ -155,8 +155,8 @@
       ]],
       ["a",{href:"http://www.mathjax.org/"},["www.mathjax.org"]],
       ["span",{id: "MathJax_HelpClose", onclick: HELP.Remove,
-               onkeydown: HELP.Keydown, tabIndex: 0,
-               "aria-label": "Close", "aria-describedby": "Close window"},
+               onkeydown: HELP.Keydown, tabIndex: 0, "aria-label": "Close",
+               "aria-describedby": LOCALE._(["HelpDialog","CloseWindow"],"Close window")},
         [["span",{},["\u00D7"]]]
       ]
     ]));

--- a/unpacked/extensions/HelpDialog.js
+++ b/unpacked/extensions/HelpDialog.js
@@ -58,6 +58,9 @@
         "-khtml-box-shadow":"0px 10px 20px #808080",  // Konqueror
         filter: "progid:DXImageTransform.Microsoft.dropshadow(OffX=2, OffY=2, Color='gray', Positive='true')" // IE
       },
+      "#MathJax_Help.MathJax_MousePost": {
+        outline:"none"
+      },
       
       "#MathJax_HelpContent": {
         overflow:"auto", "text-align":"left", "font-size":"80%",
@@ -93,6 +96,9 @@
       },
       "#MathJax_HelpClose:hover span": {
         "background-color":"#CCC!important"
+      },
+      "#MathJax_HelpClose:hover:focus": {
+        outline:"none"
       }
     }
   });
@@ -100,11 +106,11 @@
   /*
    *  Handle the Help Dialog box
    */
-  HELP.Dialog = function () {
-    LOCALE.loadDomain("HelpDialog",["Post",HELP]);
+  HELP.Dialog = function (event) {
+    LOCALE.loadDomain("HelpDialog",["Post",HELP,event]);
   };
   
-  HELP.Post = function () {
+  HELP.Post = function (event) {
     this.div = MENU.Background(this);
     var help = HTML.addElement(this.div,"div",{
       id: "MathJax_Help", tabIndex: 0, onkeydown: HELP.Keydown
@@ -160,6 +166,7 @@
         [["span",{},["\u00D7"]]]
       ]
     ]));
+    if (event.type === "mouseup") help.className += " MathJax_MousePost";
     help.focus();
     LOCALE.setCSS(help);
     var doc = (document.documentElement||{});

--- a/unpacked/extensions/HelpDialog.js
+++ b/unpacked/extensions/HelpDialog.js
@@ -162,7 +162,7 @@
       ["a",{href:"http://www.mathjax.org/"},["www.mathjax.org"]],
       ["span",{id: "MathJax_HelpClose", onclick: HELP.Remove,
                onkeydown: HELP.Keydown, tabIndex: 0, role: "button",
-	       "aria-label": LOCALE._(["HelpDialog","CloseWindow"],"Close window")},
+	       "aria-label": LOCALE._(["HelpDialog","CloseDialog"],"Close help dialog")},
         [["span",{},["\u00D7"]]]
       ]
     ]));

--- a/unpacked/extensions/MathEvents.js
+++ b/unpacked/extensions/MathEvents.js
@@ -161,6 +161,7 @@
     // Keydown event handler. Should only fire on Space key.
     //
     Keydown: function (event, math) {
+      if (!event) event = window.event;
       if (event.keyCode === EVENT.KEY.SPACE) {
         EVENT.ContextMenu(event, this);
       };

--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -93,6 +93,9 @@
         "-khtml-box-shadow":"0px 10px 20px #808080",  // Konqueror
         filter: "progid:DXImageTransform.Microsoft.dropshadow(OffX=2, OffY=2, Color='gray', Positive='true')" // IE
       },
+      "#MathJax_About.MathJax_MousePost": {
+        outline:"none"
+      },
 
       ".MathJax_Menu": {
         position:"absolute", "background-color":"white", color:"black",
@@ -202,6 +205,9 @@
       },
       ".MathJax_MenuClose:hover span": {
         "background-color":"#CCC!important"
+      },
+      ".MathJax_MenuClose:hover:focus": {
+        outline:"none"
       }
     }
   });
@@ -1001,7 +1007,7 @@
   /*
    *  Handle the ABOUT box
    */
-  MENU.About = function () {
+  MENU.About = function (event) {
     var HTMLCSS = OUTPUT["HTML-CSS"] || {};
     var font = MENU.About.GetFont();
     var format = MENU.About.GetFormat();
@@ -1034,6 +1040,7 @@
                "aria-label": "Close", "aria-describedby": _("CloseWindow","Close window")},
         [["span",{},"\u00D7"]]]
     ]);
+    if (event.type === "mouseup") about.className += " MathJax_MousePost";
     about.focus();
     MathJax.Localization.setCSS(about);
     var doc = (document.documentElement||{});
@@ -1088,9 +1095,9 @@
   /*
    *  Handle the MathJax HELP menu
    */
-  MENU.Help = function () {
+  MENU.Help = function (event) {
     AJAX.Require("[MathJax]/extensions/HelpDialog.js",
-                 function () {MathJax.Extension.Help.Dialog()});
+                 function () {MathJax.Extension.Help.Dialog({type:event.type})});
   };
 
   /*

--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -1020,7 +1020,7 @@
       ["span",{className:"MathJax_MenuClose",id:"MathJax_AboutClose",
                onclick:MENU.About.Remove,
                onkeydown: MENU.About.Keydown, tabIndex: 0,
-               "aria-label": "Close", "aria-describedby": "Close window"},
+               "aria-label": "Close", "aria-describedby": _("CloseWindow","Close window")},
         [["span",{},"\u00D7"]]]
     ]);
     about.focus();

--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -383,6 +383,7 @@
         HOVER.UnHover(MENU.jax);
       }
       MENU.Unfocus(menu);
+      if (event.type === "mousedown") MENU.CurrentNode().blur();
       return FALSE(event);
     },
 

--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -1062,7 +1062,7 @@
       ["span",{className:"MathJax_MenuClose",id:"MathJax_AboutClose",
                onclick:MENU.About.Remove,
                onkeydown: MENU.About.Keydown, tabIndex: 0, role: "button",
-               "aria-label": _("CloseWindow","Close window")},
+               "aria-label": _("CloseAboutDialog","Close about MathJax dialog")},
         [["span",{},"\u00D7"]]]
     ]);
     if (event.type === "mouseup") about.className += " MathJax_MousePost";

--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -152,10 +152,19 @@
       ".MathJax_MenuDisabled": {
         color:"GrayText"
       },
-
       ".MathJax_MenuActive": {
         "background-color": (isPC ? "Highlight" : "#606872"),
         color: (isPC ? "HighlightText" : "white")
+      },
+
+      ".MathJax_MenuDisabled:focus, .MathJax_MenuLabel:focus": {
+        "background-color": "#E8E8E8"
+      },
+      ".MathJax_ContextMenu:focus": {
+        outline:"none"
+      },
+      ".MathJax_ContextMenu .MathJax_MenuItem:focus": {
+        outline:"none"
       },
 
       "#MathJax_AboutClose": {
@@ -282,6 +291,8 @@
         menuItem: this, className: "MathJax_Menu", onkeydown: MENU.Keydown,
         role: "navigation"
       });
+      if (event.type === "contextmenu" || event.type === "mouseover")
+        menu.className += " MathJax_ContextMenu";
       if (!forceLTR) {MathJax.Localization.setCSS(menu)}
 
       for (var i = 0, m = this.items.length; i < m; i++) {this.items[i].Create(menu)}

--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -311,7 +311,7 @@
 
       div.appendChild(menu);
       this.posted = true;
-      menu.style.width = (menu.offsetWidth+2) + "px";
+      if (menu.offsetWidth) menu.style.width = (menu.offsetWidth+2) + "px";
       if (event) {
         var x = event.pageX, y = event.pageY;
       }
@@ -321,7 +321,7 @@
       }
       if (!parent) {
         var node = MENU.CurrentNode() || event.target;
-        if (!x && !y && node) {
+        if ((event.type === "keydown" || (!x && !y)) && node) {
           var offsetX = window.pageXOffset || document.documentElement.scrollLeft;
           var offsetY = window.pageYOffset || document.documentElement.scrollTop;
           var rect = node.getBoundingClientRect();

--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -282,7 +282,7 @@
      *  Display the menu
      */
     Post: function (event,parent,forceLTR) {
-      if (!event) {event = window.event};
+      if (!event) {event = window.event||{}}
       var div = document.getElementById("MathJax_MenuFrame");
       if (!div) {
         div = MENU.Background(this);
@@ -312,10 +312,8 @@
       div.appendChild(menu);
       this.posted = true;
       if (menu.offsetWidth) menu.style.width = (menu.offsetWidth+2) + "px";
-      if (event) {
-        var x = event.pageX, y = event.pageY;
-      }
-      if (!x && !y && event && event.clientX && event.clientY) {
+      var x = event.pageX, y = event.pageY;
+      if (!x && !y && "clientX" in event) {
         x = event.clientX + document.body.scrollLeft + document.documentElement.scrollLeft;
         y = event.clientY + document.body.scrollTop  + document.documentElement.scrollTop;
       }
@@ -331,7 +329,7 @@
         if (x + menu.offsetWidth > document.body.offsetWidth - this.margin)
            {x = document.body.offsetWidth - menu.offsetWidth - this.margin}
         if (MENU.isMobile) {x = Math.max(5,x-Math.floor(menu.offsetWidth/2)); y -= 20}
-        if (event) {MENU.skipUp = event.isContextMenu;}
+        MENU.skipUp = event.isContextMenu;
       } else {
         var side = "left", mw = parent.offsetWidth;
         x = (MENU.isMobile ? 30 : mw - 2); y = 0;

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -323,6 +323,7 @@
     Element: function (type,def,content) {
       if (type.substr(0,4) === "mjx-") {
         if (!def) def = {};
+        if (def.isMathJax == null) def.isMathJax = true;
         if (def.className) def.className = type+" "+def.className; else def.className = type;
       }
       return this.HTMLElement("span",def,content);
@@ -379,7 +380,7 @@
           //
           // Zoom box requires an outer container to get the positioning right.
           //
-          var NODE = CHTML.Element("mjx-chtml",{className:"MJXc-display"});
+          var NODE = CHTML.Element("mjx-chtml",{className:"MJXc-display",isMathJax:false});
           NODE.appendChild(node); node = NODE;
         }
         if (HUB.Browser.noContextMenu) {
@@ -579,7 +580,7 @@
       //  Re-render at larger size
       //
       this.getMetrics(jax);
-      var node = CHTML.addElement(span,"mjx-chtml",{style:{"font-size":Math.floor(CHTML.scale*100)+"%"}});
+      var node = CHTML.addElement(span,"mjx-chtml",{style:{"font-size":Math.floor(CHTML.scale*100)+"%"},isMathJax:false});
       this.idPostfix = "-zoom"; jax.root.toCommonHTML(node); this.idPostfix = "";
       //
       //  Adjust margins to prevent overlaps at the edges

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -265,6 +265,22 @@
           border: 0, padding: 0, margin: 0
         },
 
+        // Focus elements for keyboard tabbing.
+        ".MathJax:focus": (
+          (MathJax.Hub.Browser.isSafari || MathJax.Hub.Browser.isChrome) ? {
+            display:"inline-block",
+            outline:"none",
+            margin:"-3px",
+            padding:"3px",
+            "-webkit-box-shadow": "0px 0px 5px #345, inset 0px 0px 5px #345",
+            "box-shadow": "0px 0px 5px #345, inset 0px 0px 5px #345"
+          } : {
+            display:"inline-block",
+            outline:"none",
+            border:"1px dotted",
+            margin:"-1px"
+          }),
+
         ".MathJax_Display": {
           position: "relative",
           display: "block!important",
@@ -344,22 +360,6 @@
         "#MathJax_Tooltip *": {
           filter: "none", opacity:1, background:"transparent" // for IE
         },
-
-        // Focus elements for keyboard tabbing.
-        ".MathJax:focus": (
-          (MathJax.Hub.Browser.isSafari || MathJax.Hub.Browser.isChrome) ? {
-            display:"inline-block",
-            outline:"none",
-            margin:"-3px",
-            padding:"3px",
-            "-webkit-box-shadow": "0px 0px 5px #345, inset 0px 0px 5px #345",
-            "box-shadow": "0px 0px 5px #345, inset 0px 0px 5px #345"
-          } : {
-            display:"inline-block",
-            outline:"none",
-            border:"1px dotted",
-            margin:"-1px"
-          }),
 
         //
         //  Used for testing web fonts against the default font used while
@@ -2876,7 +2876,7 @@
     
     MML.math.Augment({
       toHTML: function (span,node,phase) {
-        var stack, box, html, math;
+        var stack, box, html, math, SPAN = span;
         //
         //  Phase I lays out the math, but doesn't measure the final math yet
         //  (that is done for a chunk at a time, to avoid reflows)
@@ -2934,7 +2934,7 @@
           if (math && math.bbox.width != null) {
             span.style.minWidth = (math.bbox.minWidth || span.style.width);
             span.style.width = math.bbox.width;
-            box.style.width = stack.style.width = "100%";
+            box.style.width = stack.style.width = SPAN.style.width = "100%";
           }
           //
           //  Add color (if any)

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -2103,6 +2103,7 @@
           if (alttext && !svg.element.getAttribute("aria-label")) span.setAttribute("aria-label",alttext);
           if (!svg.element.getAttribute("role")) span.setAttribute("role","math");
 //        span.setAttribute("tabindex",0);  // causes focus outline, so disable for now
+          svg.element.setAttribute("focusable","false");
           span.appendChild(svg.element);
           svg.element = null;
           //


### PR DESCRIPTION
This pull request includes:

* a few adjustments to the CSS to make the look for mouse (as opposed to keyboard) users more consistent with the current MathJax menu without interfering with the keyboard usage (I hope). 
    * The focus outline is not shown if the menu is opened by mouse (but focus is still set).
    * The focus outline is not shown for dialog boxes opened by mouse (but focus is still set).
    * The focus outline is not shown for close buttons when clicked by mouse
    * The focus is not shown on the math element after a menu or dialog is closed by mouse click (but is if it is closed by keyboard action).

    So the only significant difference for mouse users from the current UI is that clicking on a math element focuses it and shows the focus outline.  (Note that we probably need to implement something for `<maction>` elements so that they can get the focus and be activated by keyboard and screen reader users.  I also haven't checked href's within the math to see if they are accessible.)

* Localization of the "Close Window" string that is used on the close buttons (though I'm wondering if this would be better as "Close Dialog" or "Close Pop-up" since it is not actually the window that is being closed).

* A fix that makes sure `aria-` and `role` attributes show up as actual attributes in the DOM.

* A fix to HTML-CSS so that the focus highlighting will be full width when the math is full width (e.g., when there is a `\tag`, or with percentage-width tables, or with the `multline` environment).

* Fixes for handling of keyboard and menus in IE < 9.

* Fix so that SVG elements won't be focusable in IE.

* Fix Error jax so that [Math Processing Error] elements work with keyboard menus.