### PR TITLE
Clipping bug with large number, use auto in clip rect?

### DIFF
--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -1249,8 +1249,8 @@
         if (!this.msieClipRectBug && !bbox.noclip && !noclip) {
           var dd = 3/this.em;
           var H = (bbox.H == null ? bbox.h : bbox.H), D = (bbox.D == null ? bbox.d : bbox.D);
-          var t = HH - H - dd, b = HH + D + dd, l = 'auto', r = 'auto';
-          span.style.clip = "rect("+l+" "+r+" "+this.Em(b)+" "+this.Em(l)+")";
+          var t = HH - H - dd, b = HH + D + dd, l = -1000, r = 1000;
+          span.style.clip = "rect("+this.Em(t)+" "+this.Em(r)+" "+this.Em(b)+" "+this.Em(l)+")";
         }
       }
       // Place the box

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -1249,8 +1249,8 @@
         if (!this.msieClipRectBug && !bbox.noclip && !noclip) {
           var dd = 3/this.em;
           var H = (bbox.H == null ? bbox.h : bbox.H), D = (bbox.D == null ? bbox.d : bbox.D);
-          var t = HH - H - dd, b = HH + D + dd, l = -1000, r = 1000;
-          span.style.clip = "rect("+this.Em(t)+" "+this.Em(r)+" "+this.Em(b)+" "+this.Em(l)+")";
+          var t = HH - H - dd, b = HH + D + dd, l = 'auto', r = 'auto';
+          span.style.clip = "rect("+l+" "+r+" "+this.Em(b)+" "+this.Em(l)+")";
         }
       }
       // Place the box

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -1249,8 +1249,8 @@
         if (!this.msieClipRectBug && !bbox.noclip && !noclip) {
           var dd = 3/this.em;
           var H = (bbox.H == null ? bbox.h : bbox.H), D = (bbox.D == null ? bbox.d : bbox.D);
-          var t = HH - H - dd, b = HH + D + dd, l = -1000, r = 1000;
-          span.style.clip = "rect("+this.Em(t)+" "+this.Em(r)+" "+this.Em(b)+" "+this.Em(l)+")";
+          var t = HH - H - dd, b = HH + D + dd, l = 'auto', r = 'auto';
+          span.style.clip = "rect("+this.Em(t)+" "+r+" "+this.Em(b)+" "+l+")";
         }
       }
       // Place the box

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -615,9 +615,7 @@
         }
         font = this.lookupChar(variant,n); c = font[n];
         if (c) {
-          if ((c[5] && c[5].space) || (c[5] === "" && c[0]+c[1] === 0)) {
-            svg.Add(BBOX.RECT(0, 0, c[2]),svg.w,0)
-          } else {
+          if ((c[5] && c[5].space) || (c[5] === "" && c[0]+c[1] === 0)) {svg.w += c[2]} else {
             c = [scale,font.id+"-"+n.toString(16).toUpperCase()].concat(c);
             svg.Add(BBOX.GLYPH.apply(BBOX,c),svg.w,0);
           }

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -615,7 +615,9 @@
         }
         font = this.lookupChar(variant,n); c = font[n];
         if (c) {
-          if ((c[5] && c[5].space) || (c[5] === "" && c[0]+c[1] === 0)) {svg.w += c[2]} else {
+          if ((c[5] && c[5].space) || (c[5] === "" && c[0]+c[1] === 0)) {
+            svg.Add(BBOX.RECT(0, 0, c[2]),svg.w,0)
+          } else {
             c = [scale,font.id+"-"+n.toString(16).toUpperCase()].concat(c);
             svg.Add(BBOX.GLYPH.apply(BBOX,c),svg.w,0);
           }


### PR DESCRIPTION
Proposing a fix for https://github.com/mathjax/MathJax/issues/1314

There seems no reason to clip to 1,000 in the span, maybe you could
just auto clip, which should clip to the content. Alternatively those
numbers could just be very high?