### PR TITLE
Adds configuration for excluding MathJax elements from tab order.

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -2464,7 +2464,8 @@ MathJax.Hub = {
   },
 
   getTabOrder: function() {
-    return this.config.menuSettings.inTabOrder ? 0 : -1},
+    return this.config.menuSettings.inTabOrder ? 0 : -1;
+  },
 
   // Old browsers (e.g. Internet Explorer <= 8) do not support trim().
   SplitList: ("trim" in String.prototype ?

--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -1880,7 +1880,7 @@ MathJax.Hub = {
     showMathMenu: true,      // attach math context menu to typeset math?
     showMathMenuMSIE: true,  // separtely determine if MSIE should have math menu
                              //  (since the code for that is a bit delicate)
-
+    
     menuSettings: {
       zoom: "None",        //  when to do MathZoom
       CTRL: false,         //    require CTRL for MathZoom?
@@ -1896,6 +1896,7 @@ MathJax.Hub = {
       mpContext: false,    //  true means pass menu events to MathPlayer in IE
       mpMouse: false,      //  true means pass mouse events to MathPlayer in IE
       texHints: true,      //  include class names for TeXAtom elements
+      inTabOrder: false,    // set to false if math elements should be included in the tabindex
       semantics: false     //  add semantics tag with original form in MathML output
     },
     
@@ -2367,14 +2368,14 @@ MathJax.Hub = {
       error.oncontextmenu = EVENT.Menu;
       error.onmousedown = EVENT.Mousedown;
       error.onkeydown = EVENT.Keydown;
-      error.tabIndex = 0;
+      error.tabIndex = this.getTabOrder();
     } else {
       MathJax.Ajax.Require("[MathJax]/extensions/MathEvents.js",function () {
         var EVENT = MathJax.Extension.MathEvents.Event;
         error.oncontextmenu = EVENT.Menu;
         error.onmousedown = EVENT.Mousedown;
         error.keydown = EVENT.Keydown;
-        error.tabIndex = 0;
+        error.tabIndex = this.getTabOrder();
       });
     }
     //
@@ -2461,6 +2462,9 @@ MathJax.Hub = {
     }}
     return dst;
   },
+
+  getTabOrder: function() {
+    return this.config.menuSettings.inTabOrder ? 0 : -1},
 
   // Old browsers (e.g. Internet Explorer <= 8) do not support trim().
   SplitList: ("trim" in String.prototype ?

--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -1896,7 +1896,7 @@ MathJax.Hub = {
       mpContext: false,    //  true means pass menu events to MathPlayer in IE
       mpMouse: false,      //  true means pass mouse events to MathPlayer in IE
       texHints: true,      //  include class names for TeXAtom elements
-      inTabOrder: false,    // set to false if math elements should be included in the tabindex
+      inTabOrder: true,    //  set to false if math elements should be included in the tabindex
       semantics: false     //  add semantics tag with original form in MathML output
     },
     

--- a/unpacked/config/default.js
+++ b/unpacked/config/default.js
@@ -246,6 +246,7 @@ MathJax.Hub.Config({
     mpContext: false,    //  true means pass menu events to MathPlayer in IE
     mpMouse: false,      //  true means pass mouse events to MathPlayer in IE
     texHints: true,      //  include class names for TeXAtom elements
+    inTabOrder: true,    //  set to true if math elements should be included in the tabindex
     semantics: false     //  add semantics tag with original form in MathML output
   },
   

--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -546,6 +546,9 @@
     Activate: function(event, menu) {
       var jaxs = MENU.AllNodes();
       for (var j = 0, jax; jax = jaxs[j]; j++) {
+        if (jax.tabIndex > 0) {
+          jax.oldTabIndex = jax.tabIndex;
+        }
         jax.tabIndex = -1;
       }
       MENU.posted = true;
@@ -554,7 +557,12 @@
       MENU.ActiveNode().tabIndex = -1;
       var jaxs = MENU.AllNodes();
       for (var j = 0, jax; jax = jaxs[j]; j++) {
-        jax.tabIndex = 0;
+        if (jax.oldTabIndex !== undefined) {
+          jax.tabIndex = jax.oldTabIndex
+          delete jax.oldTabIndex;
+        } else {
+          jax.tabIndex = HUB.getTabOrder();
+        }
       }
       MENU.FocusNode(MENU.CurrentNode());
       MENU.posted = false;
@@ -1534,7 +1542,8 @@
           ITEM.RADIO("PlainSource","renderer", {action: MENU.Renderer, value:"PlainSource"}),
           ITEM.RULE(),
           ITEM.CHECKBOX("Fast Preview", "FastPreview"),
-          ITEM.CHECKBOX("Assistive MathML", "assistiveMML", {action:MENU.AssistiveMML})
+          ITEM.CHECKBOX("Assistive MathML", "assistiveMML", {action:MENU.AssistiveMML}),
+          ITEM.CHECKBOX("Include in Tab Order", "inTabOrder", {action:CONFIG.inTabOrder})
         ),
         ITEM.SUBMENU("MathPlayer",  {hidden:!HUB.Browser.isMSIE || !CONFIG.showMathPlayer,
                                                     disabled:!HUB.Browser.hasMathPlayer},

--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -544,26 +544,12 @@
       MENU.FocusNode(menu);
     },
     Activate: function(event, menu) {
-      var jaxs = MENU.AllNodes();
-      for (var j = 0, jax; jax = jaxs[j]; j++) {
-        if (jax.tabIndex > 0) {
-          jax.oldTabIndex = jax.tabIndex;
-        }
-        jax.tabIndex = -1;
-      }
+      MENU.UnsetTabIndex();
       MENU.posted = true;
     },
     Unfocus: function() {
       MENU.ActiveNode().tabIndex = -1;
-      var jaxs = MENU.AllNodes();
-      for (var j = 0, jax; jax = jaxs[j]; j++) {
-        if (jax.oldTabIndex !== undefined) {
-          jax.tabIndex = jax.oldTabIndex
-          delete jax.oldTabIndex;
-        } else {
-          jax.tabIndex = HUB.getTabOrder();
-        }
-      }
+      MENU.SetTabIndex();
       MENU.FocusNode(MENU.CurrentNode());
       MENU.posted = false;
     },
@@ -584,6 +570,26 @@
     },
     Left: function(event, menu) {
       MENU.MoveHorizontal(event, menu, function(x) {return x - 1;});
+    },
+    UnsetTabIndex: function () {
+      var jaxs = MENU.AllNodes();
+      for (var j = 0, jax; jax = jaxs[j]; j++) {
+        if (jax.tabIndex > 0) {
+          jax.oldTabIndex = jax.tabIndex;
+        }
+        jax.tabIndex = -1;
+      }
+    },
+    SetTabIndex: function () {
+      var jaxs = MENU.AllNodes();
+      for (var j = 0, jax; jax = jaxs[j]; j++) {
+        if (jax.oldTabIndex !== undefined) {
+          jax.tabIndex = jax.oldTabIndex
+          delete jax.oldTabIndex;
+        } else {
+          jax.tabIndex = HUB.getTabOrder();
+        }
+      }
     },
 
     //TODO: Move to utility class.
@@ -1336,6 +1342,9 @@
     }
   };
   
+  /*
+   *  Toggle assistive MML settings
+   */
   MENU.AssistiveMML = function (item,restart) {
     var AMML = MathJax.Extension.AssistiveMML;
     if (!AMML) {
@@ -1543,7 +1552,7 @@
           ITEM.RULE(),
           ITEM.CHECKBOX("Fast Preview", "FastPreview"),
           ITEM.CHECKBOX("Assistive MathML", "assistiveMML", {action:MENU.AssistiveMML}),
-          ITEM.CHECKBOX("Include in Tab Order", "inTabOrder", {action:CONFIG.inTabOrder})
+          ITEM.CHECKBOX("Include in Tab Order", "inTabOrder")
         ),
         ITEM.SUBMENU("MathPlayer",  {hidden:!HUB.Browser.isMSIE || !CONFIG.showMathPlayer,
                                                     disabled:!HUB.Browser.hasMathPlayer},

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -389,7 +389,7 @@
           onmouseover:EVENT.Mouseover, onmouseout:EVENT.Mouseout, onmousemove:EVENT.Mousemove,
 	  onclick:EVENT.Click, ondblclick:EVENT.DblClick,
           // Added for keyboard accessible menu.
-          onkeydown: EVENT.Keydown, tabIndex: "0"  
+          onkeydown: EVENT.Keydown, tabIndex: HUB.getTabOrder()
         });
         if (jax.CHTML.display) {
           //

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -578,7 +578,7 @@
           onmousemove:EVENT.Mousemove, onclick:EVENT.Click,
           ondblclick:EVENT.DblClick,
           // Added for keyboard accessible menu.
-          onkeydown: EVENT.Keydown, tabIndex: "0"
+          onkeydown: EVENT.Keydown, tabIndex: HUB.getTabOrder()
         });
 	if (HUB.Browser.noContextMenu) {
 	  span.ontouchstart = TOUCH.start;

--- a/unpacked/jax/output/NativeMML/jax.js
+++ b/unpacked/jax/output/NativeMML/jax.js
@@ -328,7 +328,7 @@
         container.ondblclick    = EVENT.DblClick;
         // Added for keyboard accessible menu.
         container.onkeydown = EVENT.Keydown;
-        container.tabIndex = "0";
+        container.tabIndex = HUB.getTabOrder();
 	if (HUB.Browser.noContextMenu) {
 	  container.ontouchstart = TOUCH.start;
 	  container.ontouchend   = TOUCH.end;

--- a/unpacked/jax/output/PlainSource/jax.js
+++ b/unpacked/jax/output/PlainSource/jax.js
@@ -91,7 +91,7 @@
           ondblclick: EVENT.DblClick,
           // Added for keyboard accessible menu.
           onkeydown: EVENT.Keydown,
-          tabIndex: "0"
+          tabIndex: HUB.getTabOrder()
         },[["span"]]);
         if (HUB.Browser.noContextMenu) {
           span.ontouchstart = TOUCH.start;

--- a/unpacked/jax/output/PreviewHTML/jax.js
+++ b/unpacked/jax/output/PreviewHTML/jax.js
@@ -199,7 +199,7 @@
           onmouseover:EVENT.Mouseover, onmouseout:EVENT.Mouseout, onmousemove:EVENT.Mousemove,
 	  onclick:EVENT.Click, ondblclick:EVENT.DblClick,
           // Added for keyboard accessible menu.
-          onkeydown: EVENT.Keydown, tabIndex: "0"  
+          onkeydown: EVENT.Keydown, tabIndex: HUB.getTabOrder()
         });
 	if (HUB.Browser.noContextMenu) {
 	  span.ontouchstart = TOUCH.start;

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -222,7 +222,7 @@
           onmouseover:EVENT.Mouseover, onmouseout:EVENT.Mouseout, onmousemove:EVENT.Mousemove,
 	  onclick:EVENT.Click, ondblclick:EVENT.DblClick,
           // Added for keyboard accessible menu.
-          onkeydown: EVENT.Keydown, tabIndex: "0"
+          onkeydown: EVENT.Keydown, tabIndex: HUB.getTabOrder()
         });
 	if (HUB.Browser.noContextMenu) {
 	  span.ontouchstart = TOUCH.start;


### PR DESCRIPTION
Adds a configuration parameter for including/excluding elements from the TabOrder.
The parameter is true/false, hence the actual tabIndex is returned with a function, rather than taken from a field. 
