### PR TITLE
Don't die if script has been removed from document

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -2380,7 +2380,7 @@ MathJax.Hub = {
     //
     var node = document.getElementById(error.id);
     if (node) node.parentNode.removeChild(node);
-    script.parentNode.insertBefore(error,script);
+    if (script.parentNode) script.parentNode.insertBefore(error,script);
     if (script.MathJax.preview) {script.MathJax.preview.innerHTML = ""}
     //
     //  Save the error for debugging purposes


### PR DESCRIPTION
On our site, which displays a live preview of math as users type it in, it appears that if users type too fast, MathJax will die and not display any more math.  In the console, it complains that "b.parentNode is null".  This patch checks b.parentNode (a.k.a. script.parentNode in the non-minified version) before calling b.parentNode.insertBefore().

I suppose it would be better to check script.parentNode earlier in the process so that MathJax doesn't waste time processing something that won't be displayed, but this patch seems to work, and should probably be done anyways.