### PR TITLE
mhchem.js update - first version - request for discussion

### DIFF
--- a/unpacked/extensions/TeX/mhchem.js
+++ b/unpacked/extensions/TeX/mhchem.js
@@ -48,7 +48,6 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
     //
     Init: function (string) { this.string = string; },
 
-
     //
     //  This converts the CE string to a TeX string.
     //
@@ -210,7 +209,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
       'else': /^./,
       'else2': /^./,
       'space': /^\s/,
-      'spaces': /^\s+/,
+      'space A': /^\s(?=[A-Z\\$])/,
       'a-z': /^[a-z]+/,
       'letters': /^(?:[a-zA-Z\u03B1-\u03C9\u0391-\u03A9?@]|(?:\\(?:alpha|beta|gamma|delta|epsilon|zeta|eta|theta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|tau|upsilon|phi|chi|psi|omega|Alpha|Beta|Gamma|Delta|Epsilon|Zeta|Eta|Theta|Iota|Kappa|Lambda|Mu|Nu|Xi|Omicron|Pi|Rho|Sigma|Tau|Upsilon|Phi|Chi|Psi|Omega)(?:\ |(?![a-zA-Z]))))+/,
       '\\greek': /^\\(?:alpha|beta|gamma|delta|epsilon|zeta|eta|theta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|tau|upsilon|phi|chi|psi|omega|Alpha|Beta|Gamma|Delta|Epsilon|Zeta|Eta|Theta|Iota|Kappa|Lambda|Mu|Nu|Xi|Omicron|Pi|Rho|Sigma|Tau|Upsilon|Phi|Chi|Psi|Omega)(?:\ |(?![a-zA-Z]))/,
@@ -272,7 +271,6 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
       '\\color{(...)}': /^\\color\{?(\\[a-z]+)\}?(?=\{)/,
       'oxidation$': /^-?[IVX]+$/,
       '1/2$': /^[0-9]+\/[0-9]+$/,
-      'amount nX': /^[a-z](?=\s*[A-Z])/,
       'amount': function (input) {
         var match;
         var a = this['_findObserveGroups'](input, '', '$', '$', '');
@@ -282,7 +280,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
             return { match: match[0], remainder: input.substr(match[0].length) };
           }
         } else {
-          match = input.match(/^(?:(?:\([0-9]+\/[0-9]+\)|[0-9]+\/[0-9]+|[0-9]+[.,][0-9]+|\.[0-9]+|[0-9]+|[0-9]+)(?:[a-z](?=[A-Z]))?)/);
+          match = input.match(/^(?:(?:(?:\([0-9]+\/[0-9]+\)|[0-9]+\/[0-9]+|[0-9]+[.,][0-9]+|\.[0-9]+|[0-9]+|[0-9]+)(?:[a-z](?=\s*[A-Z]))?)|[a-z](?=\s*[A-Z]))/);
           if (match) {
             return { match: match[0], remainder: input.substr(match[0].length) };
           }
@@ -459,26 +457,24 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
         '0|1|as': { action: [ 'sb=false', 'output', 'operator' ], nextState: '0' } },
       'entities': {
         '0|1': { action: 'o=', nextState: 'o' } },
-      'amount nX': {
-        '0|1|2': { action: 'a=', nextState: 'a' } },
-      'letters': {
-        '0|1|2|a|as|b|p|bp': { action: 'o=', nextState: 'o' },
-        'o': { action: 'o=' },
-        'q|dq': { action: ['output', 'o='], nextState: 'o' },
-        'd|D|qd|qD': { action: 'o after d', nextState: 'o'} },
       'orbital': {
         '0|1|2': { action: 'o=', nextState: 'o' } },
       'amount': {
-        '0|1|2': { action: 'a=', nextState: 'a' },
-        'as': { action: [ 'output', 'sb=true', 'a=' ], nextState: 'a' } },
+        '0|1|2': { action: 'a=', nextState: 'a' } },
+      'letters': {
+        '0|1|2|a|as|b|p|bp|o': { action: 'o=', nextState: 'o' },
+        'q|dq': { action: ['output', 'o='], nextState: 'o' },
+        'd|D|qd|qD': { action: 'o after d', nextState: 'o' } },
       'digits': {
         'o': { action: 'q=', nextState: 'q' },
         'd|D': { action: 'q=', nextState: 'dq' },
         'q': { action: [ 'output', 'o=' ], nextState: 'o' } },
+      'space A': {
+        'b|p|bp': {} },
       'space': {
         'a': { nextState: 'as' },
         '0': { action: 'sb=false' },
-        '1|2': { action: 'sb=true' },
+        '1': { action: 'sb=true' },
         'r|rt|rd|rdt|rdq': { action: 'output', nextState: '0' },
         'c0': { action: [ 'output', { type: 'insert', option: 'space' } ], nextState: '1' },
         '*': { action: [ 'output', 'sb=true' ], nextState: '1'} },
@@ -487,7 +483,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
       '\\\\': {
         '*': { action: [ 'output', 'copy', { type: 'insert', option: 'space' } ], nextState: '0' } },  // space, so that we don't get \\[
       '+': {
-        'a': { action: [ 'sb=false', 'output', 'operator' ], nextState: '0' },
+        'a|as': { action: [ 'sb=false', 'output', 'operator' ], nextState: '0' },
         'o': { action: 'd= kv',  nextState: 'd' },
         'd|D': { action: 'd=', nextState: 'd' },
         'q': { action: 'd=',  nextState: 'qd' },
@@ -504,7 +500,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
         'rd|rdt': { action: 'rq=', nextState: 'rdq' } },
       '...': {
         'o|d|D|dq|qd|qD': { action: [ 'output', { type: 'bond', option: '...' } ], nextState: '2' },
-        '*': { action: [ { type: 'output', option: true }, { type: 'insert', option: 'ellipsis' } ], nextState: '1' } },
+        '*': { action: [ { type: 'output', option: 1 }, { type: 'insert', option: 'ellipsis' } ], nextState: '1' } },
       '.$|.|*': {
         '*': { action: [ 'output', { type: 'insert', option: 'addition compound' } ], nextState: '0' } },
       'state of aggregation $': {
@@ -518,7 +514,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
         '0|1|2|b|p|bp|o': { action: [ 'o=', 'parenthesisLevel--' ], nextState: 'o' },
         'a|as|d|D|q|qd|qD|dq': { action: [ 'output', 'o=', 'parenthesisLevel--' ], nextState: 'o' } },
       ', ': {
-        '*': { action: [ { type: 'output', option: true }, 'comma' ], nextState: '0' } },
+        '*': { action: [ 'output', 'comma' ], nextState: '0' } },
       '^{(...)}|^($...$)': {
         '0|1|as': { action: 'b=', nextState: 'b' },
         'p': { action: 'b=', nextState: 'bp' },
@@ -550,18 +546,18 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
         '0|1': { action: [ 'beginsWithBond=true', { type: 'bond', option: '-' } ], nextState: '2' },
         '2': { action: { type: 'bond', option: '-' } },
         'a': { action: [ 'output', { type: 'insert', option: 'hyphen' } ], nextState: '1' },
-        'as': { action: [ { type: 'output', option: true }, { type: 'bond', option: '-' } ], nextState: '2' },
+        'as': { action: [ { type: 'output', option: 2 }, { type: 'bond', option: '-' } ], nextState: '2' },
         'b': { action: 'b=' },
         'o': { action: '- after o', nextState: '1' },
         'q': { action: '- after o', nextState: '1' },
         'd|qd|dq': { action: '- after d', nextState: '1' },
         'D|qD|p': { action: [ 'output', { type: 'bond', option: '-' } ], nextState: '2' } },
       '=<>': {
-        '0|1|2|a|as|o|q|d|D|qd|qD|dq': { action: [ { type: 'output', option: true }, 'bond' ], nextState: '2' } },
+        '0|1|2|a|as|o|q|d|D|qd|qD|dq': { action: [ { type: 'output', option: 2 }, 'bond' ], nextState: '2' } },
       '#': {
-        '0|1|2|a|as|o': { action: [ { type: 'output', option: true }, { type: 'bond', option: '#' } ], nextState: '2' } },
+        '0|1|2|a|as|o': { action: [ { type: 'output', option: 2 }, { type: 'bond', option: '#' } ], nextState: '2' } },
       '{}': {
-        '*': { action: { type: 'output', option: true },  nextState: '1' } },
+        '*': { action: { type: 'output', option: 1 },  nextState: '1' } },
       '{(...)}': {
         'frac': { action: 'frac-output', nextState: '1' },
         'overset': { action: 'overset-output', nextState: '1' },
@@ -571,35 +567,37 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
       '{...}': {
         '0|1|2|a|as|b|p|bp': { action: 'o=', nextState: 'o' },
         'o|d|D|q|qd|qD|dq': { action: [ 'output', 'o=' ], nextState: 'o' },
-        'c0': { action: 'copy', nextState: 'c1' },
-        'c1': { action: 'copy', nextState: '1' } },
+        'c0': { action: 'o=', nextState: 'c1' },
+        'c1': { action: [ 'o=', 'output' ], nextState: '2' } },
       '$...$': {
-        '0|1|2': { action: 'o=', nextState: 'o' },  // not 'amount'
+        'a': { action: 'a=' },  // 2$n$
+        '0|1|2|as|b|p|bp|o': { action: 'o=', nextState: 'o' },  // not 'amount'
         'as|o': { action: 'o=' },
-        'b|p|bp|q|d|D|qd|qD|dq': { action: [ 'output', 'o=' ], nextState: 'o' } },
+        'q|d|D|qd|qD|dq': { action: [ 'output', 'o=' ], nextState: 'o' } },
       '\\bond{(...)}': {
-        '*': { action: [ { type: 'output', option: true }, 'bond' ], nextState: '2' } },
+        '*': { action: [ { type: 'output', option: 2 }, 'bond' ], nextState: '2' } },
       '\\frac{(...)}': {
-        '*': { action: [ { type: 'output', option: true }, 'param1=' ], nextState: 'frac' } },
+        '*': { action: [ { type: 'output', option: 1 }, 'param1=' ], nextState: 'frac' } },
       '\\overset{(...)}': {
-        '*': { action: [ { type: 'output', option: true }, 'param1=' ], nextState: 'overset' } },
+        '*': { action: [ { type: 'output', option: 2 }, 'param1=' ], nextState: 'overset' } },
       '\\underset{(...)}': {
-        '*': { action: [ { type: 'output', option: true }, 'param1=' ], nextState: 'underset' } },
+        '*': { action: [ { type: 'output', option: 2 }, 'param1=' ], nextState: 'underset' } },
       '\\underbrace{(...)}': {
-        '*': { action: [ { type: 'output', option: true }, 'param1=' ], nextState: 'underbrace' } },
+        '*': { action: [ { type: 'output', option: 2 }, 'param1=' ], nextState: 'underbrace' } },
       '\\color{(...)}': {
-        '*': { action: [ { type: 'output', option: true }, 'param1=' ], nextState: 'color' } },
+        '*': { action: [ { type: 'output', option: 2 }, 'param1=' ], nextState: 'color' } },
       '\\ce{(...)}': {
-        '*': { action: [ { type: 'output', option: true }, 'ce' ], nextState: '1' } },
+        '*': { action: [ { type: 'output', option: 2 }, 'ce' ], nextState: '2' } },
       '\\,': {
-        '*': { action: [ { type: 'output', option: true }, 'copy' ], nextState: '1' } },
+        '*': { action: [ { type: 'output', option: 1 }, 'copy' ], nextState: '1' } },
       '\\x': {
-        '*': { action: [ { type: 'output', option: true }, 'copy' ], nextState: 'c0' } },
+        '0|1|2|a|as|b|p|bp|o': { action: 'o=', nextState: 'c0' },
+        '*': { action: ['output', 'o='], nextState: 'c0' } },
       'others': {
-        '*': { action: [ { type: 'output', option: true }, 'copy' ], nextState: '1' } },
+        '*': { action: [ { type: 'output', option: 1 }, 'copy' ], nextState: '1' } },
       'else2': {
-        'c0': { action: 'copy', nextState: '1' },
-        'c1': { nextState: '0', revisit: true },
+        'c0': { action: [ 'o=', 'output' ], nextState: '2' },
+        'c1': { action: 'output', nextState: '0', revisit: true },
         'a': { action: 'a to o', nextState: 'o', revisit: true },
         'r|rt|rd|rdt|rdq': { action: [ 'output' ], nextState: '0', revisit: true },
         '*': { action: [ 'output', 'copy' ], nextState: '1' } }
@@ -699,22 +697,25 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
           return { type: 'comma enumeration M', p1: a };
         }
       },
-      'output': function (buffer, m, forceSb) {
+      'output': function (buffer, m, entityFollows) {
+        // entityFollows:
+        //   undefined = if we have nothing else to output, also ignore the just read space (buffer.sb)
+        //   1 = an entity follows, never omit the space if there was one before (can only apply to state 2)
+        //   2 = 1 + the entity can have an amount, so output a\, instead of converting it to o (can only apply to states a|as)
         if (!buffer.r) {
           var ret = [];
           if (!buffer.a && !buffer.b && !buffer.p &&
            !buffer.o && !buffer.q && !buffer.d &&
-           !(forceSb && buffer.sb)) {
+           !entityFollows) {
             ret = null;
           } else {
             if (buffer.sb) {
               ret.push({ type: 'entitySkip' });
             }
-            if (!buffer.o && !buffer.q && !buffer.d &&
-             !buffer.b && !buffer.p) {
+            if (!buffer.o && !buffer.q && !buffer.d && !buffer.b && !buffer.p && entityFollows!==2) {
               buffer.o = mhchemParser.go(buffer.a, 'o');
               buffer.a = undefined;
-            } else if (!buffer.o && !buffer.q && !buffer.d) {
+            } else if (!buffer.o && !buffer.q && !buffer.d && (buffer.b || buffer.p)) {
               buffer.o = mhchemParser.go(buffer.a, 'o');
               buffer.d = mhchemParser.go(buffer.b, 'bd');
               buffer.q = mhchemParser.go(buffer.p, 'pq');
@@ -841,12 +842,17 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
         'orbital': { action: 'tex-math' },
         '*': { action: 'rm' } },
       '\\x': {
-        '*': { action: 'copy' } },
+        '*': { action: 'copy', nextState: 'c0' } },
       '${(...)}$|$(...)$': {
         '*': { action: 'tex-math' } },
+      '{...}': {
+        'c0': { action: 'copy', nextState: 'c1' },
+        'c1': { action: 'copy', nextState: '0' } },
       '{(...)}': {
         '*': { action: '{text}' } },
       'else2': {
+        'c0': { action: 'copy', nextState: '0' },
+        'c1': { nextState: '0', revisit: true },
         '*': { action: 'copy' } }
     }),
     actions: {}

--- a/unpacked/extensions/TeX/mhchem.js
+++ b/unpacked/extensions/TeX/mhchem.js
@@ -1,4 +1,4 @@
-﻿/* -*- Mode: Javascript; indent-tabs-mode:nil; js-indent-level: 2 -*- */
+/* -*- Mode: Javascript; indent-tabs-mode:nil; js-indent-level: 2 -*- */
 /* vim: set ts=2 et sw=2 tw=80: */
 
 /*************************************************************

--- a/unpacked/extensions/TeX/mhchem.js
+++ b/unpacked/extensions/TeX/mhchem.js
@@ -11,6 +11,7 @@
  *  ---------------------------------------------------------------------
  *  
  *  Copyright (c) 2011-2015 The MathJax Consortium
+ *  Copyright (c) 2015-2016 Martin Hensel
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,7 +27,7 @@
  */
 
 MathJax.Extension["TeX/mhchem"] = {
-  version: "2.6.0"
+  version: "2.6.0 succ"
 };
 
 MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
@@ -40,340 +41,1177 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
    */
 
   var CE = MathJax.Object.Subclass({
-    string: "",   // the \ce string being parsed
-    i: 0,         // the current position in the string
-    tex: "",      // the partially processed TeX result
-    TEX: "",      // the full TeX result
-    atom: false,  // last processed token is an atom
-    sup: "",      // pending superscript
-    sub: "",      // pending subscript
-    presup: "",   // pending pre-superscript
-    presub: "",   // pending pre-subscript
+    string: '',   // the \ce string being parsed
     
     //
     //  Store the string when a CE object is created
     //
-    Init: function (string) {this.string = string},
+    Init: function (string) { this.string = string; },
     
-    //
-    //  These are the special characters and the methods that
-    //  handle them.  All others are passed through verbatim.
-    //
-    ParseTable: {
-      '-': "Minus",
-      '+': "Plus",
-      '(': "Open",
-      ')': "Close",
-      '[': "Open",
-      ']': "Close",
-      '<': "Less",
-      '^': "Superscript",
-      '_': "Subscript",
-      '*': "Dot",
-      '.': "Dot",
-      '=': "Equal",
-      '#': "Pound",
-      '$': "Math",
-      '\\': "Macro",
-      ' ': "Space"
-    },
-    //
-    //  Basic arrow names for reactions
-    //
-    Arrows: {
-      '->': "rightarrow",
-      '<-': "leftarrow",
-      '<->': "leftrightarrow",
-      '<=>': "rightleftharpoons",
-      '<=>>': "Rightleftharpoons",
-      '<<=>': "Leftrightharpoons",
-      '^': "uparrow",
-      'v': "downarrow"
-    },
-    
-    //
-    //  Implementations for the various bonds
-    //  (the ~ ones are hacks that don't work well in NativeMML)
-    //
-    Bonds: {
-      '-': "-",
-      '=': "=",
-      '#': "\\equiv",
-      '~': "\\tripledash",
-      '~-': "\\begin{CEstack}{}\\tripledash\\\\-\\end{CEstack}",
-      '~=': "\\raise2mu{\\begin{CEstack}{}\\tripledash\\\\-\\\\-\\end{CEstack}}",
-      '~--': "\\raise2mu{\\begin{CEstack}{}\\tripledash\\\\-\\\\-\\end{CEstack}}",
-      '-~-': "\\raise2mu{\\begin{CEstack}{}-\\\\\\tripledash\\\\-\\end{CEstack}}",
-      '...': "{\\cdot}{\\cdot}{\\cdot}",
-      '....': "{\\cdot}{\\cdot}{\\cdot}{\\cdot}",
-      '->': "\\rightarrow",
-      '<-': "\\leftarrow",
-      '??': "\\text{??}"           // unknown bond
-    },
-
     //
     //  This converts the CE string to a TeX string.
-    //  It loops through the string and calls the proper
-    //  method depending on the ccurrent character.
-    //  
+    //
     Parse: function () {
-      this.tex = ""; this.atom = false;
-      while (this.i < this.string.length) {
-        var c = this.string.charAt(this.i);
-        if (c.match(/[a-z]/i)) {this.ParseLetter()}
-        else if (c.match(/[0-9]/)) {this.ParseNumber()}
-        else {this["Parse"+(this.ParseTable[c]||"Other")](c)}
-      }
-      this.FinishAtom(true);
-      return this.TEX;
-    },
-    
-    //
-    //  Make an atom name or a down arrow
-    //  
-    ParseLetter: function () {
-      this.FinishAtom();
-      if (this.Match(/^v( |$)/)) {
-        this.tex += "{\\"+this.Arrows["v"]+"}";
-      } else {
-        this.tex += "\\text{"+this.Match(/^[a-z]+/i)+"}";
-        this.atom = true;
-      }
-    },
-    
-    //
-    //  Make a number or fraction preceeding an atom,
-    //  or a subscript for an atom.
-    //  
-    ParseNumber: function () {
-      var n = this.Match(/^\d+/);
-      if (this.atom && !this.sub) {
-        this.sub = n;
-      } else {
-        this.FinishAtom();
-        var match = this.Match(/^\/\d+/);
-        if (match) {
-          var frac = "\\frac{"+n+"}{"+match.substr(1)+"}";
-          this.tex += "\\mathchoice{\\textstyle"+frac+"}{"+frac+"}{"+frac+"}{"+frac+"}";
-        } else {
-          this.tex += n;
-          if (this.i < this.string.length) {this.tex += "\\,"}
-        }
-      }
-    },
-    
-    //
-    //  Make a superscript minus, or an arrow, or a single bond.
-    //
-    ParseMinus: function (c) {
-      if (this.atom && (this.i === this.string.length-1 || this.string.charAt(this.i+1) === " ")) {
-        this.sup += c;
-      } else {
-        this.FinishAtom();
-        if (this.string.substr(this.i,2) === "->") {this.i += 2; this.AddArrow("->"); return}
-        else {this.tex += "{-}"}
-      }
-      this.i++;
-    },
-
-    //
-    //  Make a superscript plus, or pass it through
-    //
-    ParsePlus: function (c) {
-      if (this.atom) {this.sup += c} else {this.FinishAtom(); this.tex += c}
-      this.i++;
-    },
-    
-    //
-    //  Handle dots and double or triple bonds
-    //
-    ParseDot:   function (c) {this.FinishAtom(); this.tex += "\\cdot "; this.i++},
-    ParseEqual: function (c) {this.FinishAtom(); this.tex += "{=}"; this.i++},
-    ParsePound: function (c) {this.FinishAtom(); this.tex += "{\\equiv}"; this.i++},
-
-    //
-    //  Look for (v) or (^), or pass it through
-    //
-    ParseOpen: function (c) {
-      this.FinishAtom();
-      var match = this.Match(/^\([v^]\)/);
-      if (match) {this.tex += "{\\"+this.Arrows[match.charAt(1)]+"}"}
-        else {this.tex += "{"+c; this.i++}
-    },
-    //
-    //  Allow ) and ] to get super- and subscripts
-    //
-    ParseClose: function (c) {this.FinishAtom(); this.atom = true; this.tex += c+"}"; this.i++},
-
-    //
-    //  Make the proper arrow
-    //
-    ParseLess: function (c) {
-      this.FinishAtom();
-      var arrow = this.Match(/^(<->?|<=>>?|<<=>)/);
-      if (!arrow) {this.tex += c; this.i++} else {this.AddArrow(arrow)}
-    },
-
-    //
-    //  Look for a superscript, or an up arrow
-    //  
-    ParseSuperscript: function (c) {
-      c = this.string.charAt(++this.i);
-      if (c === "{") {
-        this.i++; var m = this.Find("}");
-        if (m === "-.") {this.sup += "{-}{\\cdot}"}
-        else if (m) {this.sup += CE(m).Parse().replace(/^\{-\}/,"-")}
-      } else if (c === " " || c === "") {
-        this.tex += "{\\"+this.Arrows["^"]+"}"; this.i++;
-      } else {
-        var n = this.Match(/^(\d+|-\.)/);
-        if (n) {this.sup += n}
-      }
-    },
-    //
-    //  Look for subscripts
-    //
-    ParseSubscript: function (c) {
-      if (this.string.charAt(++this.i) == "{") {
-        this.i++; this.sub += CE(this.Find("}")).Parse().replace(/^\{-\}/,"-");
-      } else {
-        var n = this.Match(/^\d+/);
-        if (n) {this.sub += n}
+      try {
+        var a = (new this.MhchemParser()).parse(this.string);
+        return this.texify(a);
+      } catch (ex) {
+        TEX.Error(ex);
       }
     },
 
     //
-    //  Look for raw TeX code to include
+    // Core parser for mhchem syntax  (recursive)
     //
-    ParseMath: function (c) {
-      this.FinishAtom();
-      this.i++; this.tex += this.Find(c);
-    },
-    
-    //
-    //  Look for specific macros for bonds
-    //  and allow \} to have subscripts
-    //
-    ParseMacro: function (c) {
-      this.FinishAtom();
-      this.i++; var match = this.Match(/^([a-z]+|.)/i)||" ";
-      if (match === "sbond") {this.tex += "{-}"}
-      else if (match === "dbond") {this.tex += "{=}"}
-      else if (match === "tbond") {this.tex += "{\\equiv}"}
-      else if (match === "bond") {
-        var bond = (this.Match(/^\{.*?\}/)||"");
-        bond = bond.substr(1,bond.length-2);
-        this.tex += "{"+(this.Bonds[bond]||"\\text{??}")+"}";
-      }
-      else if (match === "{") {this.tex += "{\\{"}
-      else if (match === "}") {this.tex += "\\}}"; this.atom = true}
-      else {this.tex += c+match}
-    },
-    
-    //
-    //  Ignore spaces
-    //
-    ParseSpace: function (c) {this.FinishAtom(); this.i++},
-    
-    //
-    //  Pass anything else on verbatim
-    //
-    ParseOther: function (c) {this.FinishAtom(); this.tex += c; this.i++},
+    MhchemParser: function MhchemParser() {
+      'use strict';
+      var that = {};
 
-    //
-    //  Process an arrow (looking for brackets for above and below)
-    //
-    AddArrow: function (arrow) {
-      var c = this.Match(/^[CT]\[/);
-      if (c) {this.i--; c = c.charAt(0)}
-      var above = this.GetBracket(c), below = this.GetBracket(c);
-      arrow = this.Arrows[arrow];
-      if (above || below) {
-        if (below) {arrow += "["+below+"]"}
-        arrow += "{"+above+"}";
-        arrow = "\\mathrel{\\x"+arrow+"}";
-      } else {
-        arrow = "\\long"+arrow+" ";
-      }
-      this.tex += arrow;
-    },
+      //
+      // Parses mchem \ce syntax
+      //
+      // Call like
+      //   parse('H2O');
+      //
+      // Looks through that.transitions, to execute a matching action
+      // (recursive)
+      //
+      that.parse = function(input, stateMachine) {
+        if (!input) { return input; }
+        if (stateMachine === undefined) { stateMachine = 'ce'; }
+        var state = '0';
 
-    //
-    //  Handle the super and subscripts for an atom
-    //  
-    FinishAtom: function (force) {
-      if (this.sup || this.sub || this.presup || this.presub) {
-        if (!force && !this.atom) {
-          if (this.tex === "" && !this.sup && !this.sub) return;
-          if (!this.presup && !this.presub &&
-                (this.tex === "" || this.tex === "{" ||
-                (this.tex === "}" && this.TEX.substr(-1) === "{"))) {
-            this.presup = this.sup, this.presub = this.sub;  // save for later
-            this.sub = this.sup = "";
-            this.TEX += this.tex; this.tex = "";
-            return;
+        var lastInput, watchdog;
+        var output = [];
+        while (true) {
+          if (lastInput !== input) {
+            watchdog = 10;
+            lastInput = input;
+          } else {
+            watchdog--;
+          }
+          //
+          // Look for matching string in transition table
+          //
+          iterateTransitions:
+          for (var iT=0; iT<that.stateMachines[stateMachine].transitions.length; iT++) {
+            var t = that.stateMachines[stateMachine].transitions[iT];
+            var matchArray = [].concat(t.match);
+            for (var iM=0; iM<matchArray.length; iM++) {
+              var matches = that.match(matchArray[iM], input);
+              if (matches) {
+                //
+                // Look for matching state
+                //
+                for (var iA=0; iA<t.actions.length; iA++) {
+                  if (('|'+t.actions[iA].state+'|').indexOf('|'+state+'|') !== -1  ||
+                   t.actions[iA].state === '*') {
+                    //
+                    // Execute action  (recursive)
+                    //
+                    var actions = [].concat(t.actions[iA].action);
+                    for (var iAA=0; iAA<actions.length; iAA++) {
+                      var a = actions[iAA];
+                      var o;
+                      if (typeof a === 'string') {
+                        if (that.stateMachines[stateMachine].actions[a]) {
+                          o = that.stateMachines[stateMachine].actions[a](matches.match);
+                        } else if (that.actions[a]) {
+                          o = that.actions[a](matches.match);
+                        } else {
+                          throw ['InternalMhchemErrorNonExistingAction', 'Internal mhchem Error – Trying to use non-existing action'];
+                        }
+                        output = that.concatNotUndefined(output, o);
+                      } else if (typeof a === 'function') {
+                        o = a(matches.match);
+                        output = that.concatNotUndefined(output, o);
+                      } else if (a  &&  a.type) {
+                        if (that.stateMachines[stateMachine].actions[a.type]) {
+                          o = that.stateMachines[stateMachine].actions[a.type](matches.match, a.option);
+                        } else if (that.actions[a.type]) {
+                          o = that.actions[a.type](matches.match, a.option);
+                        } else {
+                          throw ['InternalMhchemErrorNonExistingAction', 'Internal mhchem Error – Trying to use non-existing action'];
+                        }
+                        output = that.concatNotUndefined(output, o);
+                      }
+                    }
+                    //
+                    // Set next state,
+                    // Shorten input,
+                    // Continue with next character
+                    //   (= apply only one transition per position)
+                    //
+                    state = t.actions[iA].nextState || state;
+                    if (input.length > 0) {
+                      if (!t.actions[iA].revisit) {
+                        input = matches.remainder;
+                      }
+                      if (!t.actions[iA].toContinue) {
+                        break iterateTransitions;
+                      }
+                    } else {
+                      return output;
+                    }
+                  }
+                }
+              }
+            }
+          }
+          //
+          // Prevent infinite loop
+          //
+          if (watchdog <= 0) {
+            throw ['MhchemErrorUnexpectedCharacter', 'mhchem Error – Unexpected character'];
           }
         }
-        if (this.sub && !this.sup) {this.sup = "\\Space{0pt}{0pt}{.2em}"} // forces subscripts to align properly
-        if ((this.presup || this.presub) && this.tex !== "{") {
-          if (!this.presup && !this.sup) {this.presup = "\\Space{0pt}{0pt}{.2em}"}
-          this.tex = "\\CEprescripts{"+(this.presub||"\\CEnone")+"}{"+(this.presup||"\\CEnone")+"}"
-                   + "{"+(this.tex !== "}" ? this.tex : "")+"}"
-                   + "{"+(this.sub||"\\CEnone")+"}{"+(this.sup||"\\CEnone")+"}"
-                   + (this.tex === "}" ? "}" : "");
-          this.presub = this.presup = "";
-        } else {
-          if (this.sup) this.tex += "^{"+this.sup+"}";
-          if (this.sub) this.tex += "_{"+this.sub+"}";
-        }
-        this.sup = this.sub = "";
-      }
-      this.TEX += this.tex; this.tex = "";
-      this.atom = false;
-    },
-    
-    //
-    //  Find a bracket group and handle C and T prefixes
-    //
-    GetBracket: function (c) {
-      if (this.string.charAt(this.i) !== "[") {return ""}
-      this.i++; var bracket = this.Find("]");
-      if (c === "C") {bracket = "\\ce{"+bracket+"}"} else
-      if (c === "T") {
-        if (!bracket.match(/^\{.*\}$/)) {bracket = "{"+bracket+"}"}
-        bracket = "\\text"+bracket;
       };
-      return bracket;
+      that.concatNotUndefined = function(a, b) {
+        if (!b) { return a; }
+        if (!a) { return [].concat(b); }
+        return a.concat(b);
+      };
+
+      //
+      // Matching helpers (mostly RegExps)
+      //
+      that.match = function (m, input) {
+        var f = {
+          'empty': /^$/,
+          'else': /^./,
+          'space': /^\s+/,
+          'a-z': /^[a-z]/,
+          'letters': /^(?:[a-zA-Zα-ωΑ-Ω]|(?:\\(?:alpha|beta|gamma|delta|epsilon|zeta|eta|theta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|tau|upsilon|phi|chi|psi|omega|Alpha|Beta|Gamma|Delta|Epsilon|Zeta|Eta|Theta|Iota|Kappa|Lambda|Mu|Nu|Xi|Omicron|Pi|Rho|Sigma|Tau|Upsilon|Phi|Chi|Psi|Omega)(?:\ |(?![a-zA-Z]))))+/,
+          '\\greek': /^\\(?:alpha|beta|gamma|delta|epsilon|zeta|eta|theta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|tau|upsilon|phi|chi|psi|omega|Alpha|Beta|Gamma|Delta|Epsilon|Zeta|Eta|Theta|Iota|Kappa|Lambda|Mu|Nu|Xi|Omicron|Pi|Rho|Sigma|Tau|Upsilon|Phi|Chi|Psi|Omega)(?:\ |(?![a-zA-Z]))/,
+          'one lowercase letter $': /^(?:\$?[a-zα-ω]\$?|\$?\\(?:alpha|beta|gamma|delta|epsilon|zeta|eta|theta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|tau|upsilon|phi|chi|psi|omega|Alpha|Beta|Gamma|Delta|Epsilon|Zeta|Eta|Theta|Iota|Kappa|Lambda|Mu|Nu|Xi|Omicron|Pi|Rho|Sigma|Tau|Upsilon|Phi|Chi|Psi|Omega)\$?(?:\ |(?![a-zA-Z])))$/,
+          'digits': /^[0-9]+/,
+          '-9.,9': /^-?(?:[0-9]+(?:[.,][0-9]+)?|[0-9]*(?:\.[0-9]+))/,
+          '-9.,9 no missing 0': /^-?[0-9]+(?:[.,][0-9]+)?/,
+          'state of aggregation $':  function (input) {
+            var a = this['_findObserveGroups'](input, '', /^\([a-z]{1,3}(?=[\),])/, ')', '');
+            if (a  &&  a.remainder.match(/^(\s|$)/))  return a;
+            return null;
+          },
+          '\{[(': /^(?:\\\{|\[|\()/,
+          ')]\}': /^(?:\)|\]|\\\})/,
+          ',': /^,/,
+          '.': /^\./,
+          '.$': /^\.(?=\s|$|\{\})/,
+          "*": /^\*/,
+          '^{(...)}': function (input) { return this['_findObserveGroups'](input, '^{', '', '', '}'); },
+          '^($...$)': function (input) { return this['_findObserveGroups'](input, '^', '$', '$', ''); },
+          '^(...)': /^\^([0-9]+|[^\\]|\\(?:[a-zA-Z]+(?=\s|$|\{|\})|[^a-zA-Z]))/,
+          '_{(...)}': function (input) { return this['_findObserveGroups'](input, '_{', '', '', '}'); },
+          '_($...$)': function (input) { return this['_findObserveGroups'](input, '_', '$', '$', ''); },
+          '_(...)': /^_(-?[0-9]+|[^\\]|\\(?:[a-zA-Z]+(?=\s|$|\{|\})|[^a-zA-Z]))/,
+          '{}': /^\{\}/,
+          '{...}': function (input) { return this['_findObserveGroups'](input, '', '{', '}', ''); },
+          '{(...)}': function (input) { return this['_findObserveGroups'](input, '{', '', '', '}'); },
+          '$...$': function (input) { return this['_findObserveGroups'](input, '', '$', '$', ''); },
+          '${(...)}$': function (input) { return this['_findObserveGroups'](input, '${', '', '', '}$'); },
+          '$(...)$': function (input) { return this['_findObserveGroups'](input, '$', '', '', '$'); },
+          '=': /^=/,
+          '#': /^#/,
+          '+': /^\+/,
+          '-$': /^-(?=[\s_{},/]|$|\([a-z]+\))/,  // end = space, {, }, $, state-of-aggregation
+          '-9': /^-(?=\d)/,
+          '-': /^-/,
+          'operator': /^(?:\+|(?:-|=|\\pm|\$\\pm\$)(?=\s|$))/,
+          'arrowUpDown': /^(?:v|\(v\)|\^|\(\^\))(?=\s|$)/,
+          '\\bond{(...)}': function (input) { return this['_findObserveGroups'](input, '\\bond{', '', '', '}'); },
+          '->': /^(?:<->|<-->|->|<-|<=>>|<<=>|<=>)/,
+          'CMT': /^[CMT](?=\[)/,
+          '[(...)]': function (input) { return this['_findObserveGroups'](input, '[', '', '', ']'); },
+          '&': /^&/,
+          '\\\\': /^\\\\/,
+          '\\,': /^\\(?:[,\ $])/,
+          '\\x': /^\\(?:[a-zA-Z]+|\{|\}|[_])/,
+          '\\frac{(...)}': function (input) { return this['_findObserveGroups'](input, '\\frac{', '', '', '}'); },
+          '\\overset{(...)}': function (input) { return this['_findObserveGroups'](input, '\\overset{', '', '', '}'); },
+          '\\underset{(...)}': function (input) { return this['_findObserveGroups'](input, '\\underset{', '', '', '}'); },
+          '\\underbrace{(...)}': function (input) { return this['_findObserveGroups'](input, '\\underbrace{', '', '', '}_'); },
+          '\\ce{(...)}': function (input) { return this['_findObserveGroups'](input, '\\ce{', '', '', '}'); },
+          '\\color{(...)}': /^\\color\{?(\\[a-z]+)\}?(?=\{)/,
+          'oxidation$': /^-?[IVX]+$/,
+          '1/2$': /^[0-9]+\/[0-9]+$/,
+          'amount': function (input) {
+            var match;
+            var a = this['_findObserveGroups'](input, '', '$', '$', '');
+            if (a) {
+              match = a.match.match(/^\$\(?(?:[0-9]*[a-z]?[+\-])?[0-9]*[a-z](?:[+\-][0-9]*[a-z]?)?\)?\$$/);
+              if (match) {
+                return { match: match[0], remainder: input.substr(match[0].length) };
+              }
+            } else {
+              match = input.match(/^(?:\([0-9]+\/[0-9]+\)|[0-9]+\/[0-9]+|[0-9]+[.,][0-9]+|\.[0-9]+|[0-9]+|[a-z](?=\s|$)|[0-9]*n(?=[A-Z]))/);
+              if (match) {
+                return { match: match[0], remainder: input.substr(match[0].length) };
+              }
+            }
+            return null;
+          },
+          'formula$': function (input) {
+            if (input.match(/^\([a-z]+\)$/)) {  // state of aggregation = no formula
+              return null;
+            }
+            var match = input.match(/^(?:[a-z]|(?:[0-9\ \+\-\,\.\(\)]+[a-z])+[0-9\ \+\-\,\.\(\)]*|(?:[a-z][0-9\ \+\-\,\.\(\)]+)+[a-z]?)$/);
+            if (match) {
+              return { match: match[0], remainder: input.substr(match[0].length) };
+            }
+            return null;
+          },
+          '_findObserveGroups': function (input, begExcl, begIncl, endIncl, endExcl) {
+            var match = this['__match'](input, begExcl);
+            if (match === null)  return null;
+            input = input.substr(match.length);
+            match = this['__match'](input, begIncl);
+            if (match === null)  return null;
+            var e = this['__findObserveGroups'](input, match.length, endIncl || endExcl);
+            if (e === null)  return null;
+            return { 
+              match: input.substring(0, (endIncl ? e.endMatchEnd : e.endMatchBegin)), 
+              remainder: input.substr(e.endMatchEnd)
+            };
+          },
+          '__match': function (input, pattern) {
+            if (typeof pattern === 'string') {
+              if (input.indexOf(pattern) !== 0)  return null;
+              return pattern;
+            } else {
+              var match = input.match(pattern);
+              if (!match)  return null;
+              return match[0];
+            }
+          },
+          '__findObserveGroups': function (input, i, endChars) {
+            var braces = 0;
+            while (i < input.length) {
+              var a = input.charAt(i);
+              var match = this['__match'](input.substr(i), endChars);
+              if (match  &&  braces === 0) {
+                return { endMatchBegin: i, endMatchEnd: i + match.length };
+              } else if (a === '{') {
+                braces++;
+              } else if (a === '}') {
+                if (braces === 0) {
+                  throw ['ExtraCloseMissingOpen', 'Extra close brace or missing open brace'];
+                } else {
+                  braces--;
+                }
+              }
+              i++;
+            }
+            if (braces > 0) {
+              return null;
+            }
+            return null;
+          }
+        };
+        if (f[m] === undefined) {
+          throw ['InternalMhchemErrorNonExistingPattern', 'Internal mhchem Error – Trying to use non-existing pattern'];
+        } else if (typeof f[m] === 'function') {
+          return f[m](input);
+        } else {  // RegExp
+          var match = input.match(f[m]);
+          if (match) {
+            var mm = match[1];
+            if (mm === undefined) { mm = match[0]; }
+            return { match: mm, remainder: input.substr(match[0].length) };
+          }
+          return null;
+        }
+      };
+
+      //
+      // String buffers for parsing:
+      //
+      // that.buffer.a = amount
+      // that.buffer.o = element
+      // that.buffer.b = left-side superscript
+      // that.buffer.p = left-side subscript
+      // that.buffer.q = right-side subscript
+      // that.buffer.d = right-side superscript
+      //
+      // that.buffer.r = arrow
+      // that.buffer.rdt = arrow, script above, type
+      // that.buffer.rd = arrow, script above, content
+      // that.buffer.rqt = arrow, script below, type
+      // that.buffer.rq = arrow, script below, content
+      //
+      // that.buffer.param1
+      // that.buffer.text
+      // that.buffer.rm
+      // etc.
+      //
+      // that.buffer.sb = bool, space before
+      //
+      // that.buffer.beginsWithBond = bool
+      //
+      // These letters are also used as state names.
+      //
+      // Other states:
+      // 0 - begin of main part
+      // 1 - next entity
+      // 2 - next atom
+      // frac, overset, ...
+      // c - macro
+      //
+      that.buffer = {};
+
+      //
+      // Generic state machine actions
+      //
+      that.actions = {
+        'a=': function (m) { that.buffer.a = (that.buffer.a || '') + m; },
+        'b=': function (m) { that.buffer.b = (that.buffer.b || '') + m; },
+        'p=': function (m) { that.buffer.p = (that.buffer.p || '') + m; },
+        'o=': function (m) { that.buffer.o = (that.buffer.o || '') + m; },
+        'q=': function (m) { that.buffer.q = (that.buffer.q || '') + m; },
+        'd=': function (m) { that.buffer.d = (that.buffer.d || '') + m; },
+        'rm=': function (m) { that.buffer.rm = (that.buffer.rm || '') + m; },
+        'text=': function (m) { that.buffer.text = (that.buffer.text || '') + m; },
+        'color1=': function(m) { that.buffer.color1 = m; },
+        'insert': function (m, a) { return { type: a }; },
+        'copy': function (m) { return m; },
+        'rm': function (m) { return { type: 'rm', p1: m }; },
+        'text': function (m) { return (new MhchemParser()).parse(m, 'text'); },
+        '{text}': function (m) {
+          var ret = [ '{' ];
+          ret = that.concatNotUndefined(ret, (new MhchemParser()).parse(m, 'text'));
+          ret = that.concatNotUndefined(ret, '}');
+          return ret;
+        },
+        'tex-math': function (m) { return (new MhchemParser()).parse(m, 'tex-math'); },
+        'tex-math tight': function (m) { return (new MhchemParser()).parse(m, 'tex-math tight'); },
+        'bond': function (m, k) { return { type: 'bond', kind: k || m }; },
+        'ce': function (m) { return (new MhchemParser()).parse(m); },
+        '1/2': function (m) {
+          var n = m.match(/^([0-9]+)\/([0-9]+)$/);
+          return { type: 'frac', p1: n[1], p2: n[2] };
+        },
+        '9,9': function (m) { return (new MhchemParser()).parse(m, '9,9'); }
+      };
+
+      //
+      // State machine definitions
+      //
+      that.stateMachines = {};
+      //
+      // State machine transitions of main parser
+      //
+      that.stateMachines['ce'] = {};
+      that.stateMachines['ce'].transitions = [
+        {
+          match: 'empty',
+          actions: [ { state: '*', action: 'output' } ]
+        }, {
+          match: 'else',
+          actions: [ { state: '0|1', action: 'beginsWithBond=false', revisit: true, toContinue: true } ]
+        }, {
+          match: 'space',
+          actions: [ { state: 'a', nextState: 'as' },
+                     { state: '0|2', action: 'sb=false' },
+                     { state: '1', action: 'sb=true' },
+                     { state: 'r|rt|rd|rdt|rdq', action: 'output', nextState: '0' },
+                     { state: '*', action: [ 'output', 'sb=true' ], nextState: '1'} ]
+        }, {
+          match: '&',
+          actions: [ { state: '*', action: [ 'output', 'copy' ], nextState: '0' } ]
+        }, {
+          match: '\\\\',
+          actions: [ { state: '*', action: [ 'output', 'copy', { type: 'insert', option: 'space' } ], nextState: '0' } ]  // space, so that we don't get \\[
+        }, {
+          match: [ 'operator', 'arrowUpDown' ],
+          actions: [ { state: '0|1|2', action: [ 'operator' ], nextState: '0' } ]
+        }, {
+          match: '->',
+          actions: [ { state: '0|1|2', action: 'r=', nextState: 'r' },
+                     { state: '*', action: [ 'output', 'r=' ], nextState: 'r' } ]
+        }, {
+          match: 'CMT',
+          actions: [ { state: 'r', action: 'rdt=', nextState: 'rt' },
+                     { state: 'rd', action: 'rqt=', nextState: 'rdt' }]
+        }, {
+          match: '[(...)]',
+          actions: [ { state: 'r|rt', action: 'rd=', nextState: 'rd' },
+                     { state: 'rd|rdt', action: 'rq=', nextState: 'rdq' }]
+        }, {
+          match: 'amount',
+          actions: [ { state: '0|1|2|a', action: 'a=', nextState: 'a' } ]
+        }, {
+          match: [ '.$', '.', '*' ],
+          actions: [ { state: '*', action: [ 'output', { type: 'insert', option: 'addition compound' } ], nextState: '2' } ]
+        }, {
+          match: 'letters',
+          actions: [ { state: '0|1|2|a|as|b|p|bp', action: 'o=', nextState: 'o' },
+                     { state: 'o', action: 'o=' },
+                     { state: 'q|dq', action: ['output', 'o='], nextState: 'o' },
+                     { state: 'd|D|qd|qD', action: 'o after d', nextState: 'o'} ]
+        }, {
+          match: 'digits',
+          actions: [ { state: 'o', action: 'q=', nextState: 'q' },
+                     { state: 'd|D', action: 'q=', nextState: 'dq' } ]
+        }, {
+          match: 'state of aggregation $',
+          actions: [ { state: '0', action: [ 'output', 'sb=false', 'o=', 'output' ], nextState: '1' },
+                     { state: '*', action: [ 'output', 'state of aggregation' ], nextState: '1' } ]
+        }, {
+          match: '\{[(',
+          actions: [ { state: 'a|as|o', action: [ 'o=', 'output' ], nextState: '1' },
+                     { state: '0|1|2', action: [ 'o=', 'output' ], nextState: '1' },
+                     { state: '*', action: [ 'output', 'o=', 'output' ], nextState: '1' } ]
+        }, {
+          match: ')]\}',
+          actions: [ { state: '0|1|2|b|p|bp|o', action: 'o=', nextState: 'o' },
+                     { state: 'd|D|q|qd|qD|dq', action: [ 'output', 'o=' ], nextState: 'o' } ]
+        }, {
+          match: ',',
+          actions: [ { state: 'o|q|d|D|qd|qD|dq', action: [ 'output', { type: 'insert', option: 'comma enumeration' } ], nextState: '0' } ]
+        }, {
+          match: [ '^{(...)}', '^($...$)' ],
+          actions: [ { state: '0|1|2|as', action: 'b=', nextState: 'b' },
+                     { state: 'p', action: 'b=', nextState: 'bp' },
+                     { state: 'o', action: 'd= kv', nextState: 'D' },
+                     { state: 'q', action: 'd=', nextState: 'qD' },
+                     { state: 'd|D|qd|qD|dq', action: [ 'output', 'd=' ], nextState: 'D' } ]
+        }, {
+          match: [ '^(...)' ],
+          actions: [ { state: '0|1|2|as', action: 'b=', nextState: 'b' },
+                     { state: 'p', action: 'b=', nextState: 'bp' },
+                     { state: 'o', action: 'd= kv', nextState: 'd' },
+                     { state: 'q', action: 'd=', nextState: 'qd' },
+                     { state: 'd|D|qd|qD|dq', action: [ 'output', 'd=' ], nextState: 'd' } ]
+        }, {
+          match: [ '_{(...)}', '_($...$)', '_(...)' ],
+          actions: [ { state: '0|1|2|as', action: 'p=', nextState: 'p' },
+                     { state: 'b', action: 'p=', nextState: 'bp' },
+                     { state: 'o', action: 'q=', nextState: 'q' },
+                     { state: 'd|D', action: 'q=', nextState: 'dq' },
+                     { state: 'q|qd|qD|dq', action: [ 'output', 'q=' ], nextState: 'q' } ]
+        }, {
+          match: '+',
+          actions: [ { state: 'o',  action: 'd= kv',  nextState: 'd' },
+                     { state: 'd|D',  action: 'd=', nextState: 'd' },
+                     { state: 'q',  action: 'd=',  nextState: 'qd' },
+                     { state: 'qd|qD', action: 'd=', nextState: 'qd' },
+                     { state: 'dq', action: [ 'output', 'd=' ], nextState: 'd' } ]
+        }, {
+          match: '-$',
+          actions: [ { state: 'o|q',  action: [ 'charge or bond', 'output' ],  nextState: 'qd' },
+                     { state: 'd',  action: 'd=', nextState: 'd' },
+                     { state: 'D',  action: [ 'output', { type: 'bond', option: '-' } ], nextState: '2' },
+                     { state: 'q',  action: 'd=',  nextState: 'qd' },
+                     { state: 'qd', action: 'd=', nextState: 'qd' },
+                     { state: 'qD|dq', action: [ 'output', { type: 'bond', option: '-' } ], nextState: '2' } ]
+        }, {
+          match: '-9',
+          actions: [ { state: '2|o',  action: [ 'output', { type: 'insert', option: 'hyphen' } ], nextState: '2' } ]
+        }, {
+          match: '-',
+          actions: [ { state: '0|1',  action: [ 'beginsWithBond=true', { type: 'bond', option: '-' } ], nextState: '2' },
+                     { state: '2',  action: { type: 'bond', option: '-' } },
+                     { state: 'a',  action: [ 'output', { type: 'insert', option: 'hyphen' } ], nextState: '1' },
+                     { state: 'b',  action: 'b=' },
+                     { state: 'o',  action: '- after o', nextState: '1' },
+                     { state: 'q',  action: '- after o', nextState: '1' },
+                     { state: 'd|qd|dq',  action: '- after d', nextState: '1' },
+                     { state: 'D|qD',  action: [ 'output', { type: 'bond', option: '-' } ], nextState: '2' } ]
+        }, {
+          match: '=',
+          actions: [ { state: '0|1|2|o|q|d|D|qd|qD|dq', action: [ 'output', { type: 'bond', option: '=' } ], nextState: '1' } ]
+        }, {
+          match: '#',
+          actions: [ { state: '0|1|2|o', action: [ 'output', { type: 'bond', option: '#' } ], nextState: '1' } ]
+        }, {
+          match: '{}',
+          actions: [ { state: '*',  action: 'output',  nextState: '1' } ]
+        }, {
+          match: '{(...)}',
+          actions: [ { state: 'frac', action: 'frac-output', nextState: '1' },
+                     { state: 'overset', action: 'overset-output', nextState: '1' },
+                     { state: 'underset', action: 'underset-output', nextState: '1' },
+                     { state: 'underbrace', action: 'underbrace-output', nextState: '1' },
+                     { state: 'color', action: 'color-output', nextState: '1' } ]
+        }, {
+          match: '{...}',
+          actions: [ { state: '0|1|2|a|as|b|p|bp', action: 'o=', nextState: 'o' },
+                     { state: 'o|d|D|q|qd|qD|dq', action: [ 'output', 'o=' ], nextState: 'o' },
+                     { state: 'c0', action: 'copy', nextState: 'c1' },
+                     { state: 'c1', action: 'copy', nextState: '1' } ]
+        }, {
+          match: '$...$',
+          actions: [ { state: '0|1|2', action: 'o=', nextState: 'o' },  // not 'amount'
+                     { state: 'as|o', action: 'o=' },
+                     { state: 'b|p|bp|q|d|D|qd|qD|dq', action: [ 'output', 'o=' ], nextState: 'o' } ]
+        }, {
+          match: '\\bond{(...)}',
+          actions: [ { state: '*', action: [ 'output', 'bond' ], nextState: '1' } ]
+        }, {
+          match: '\\frac{(...)}',
+          actions: [ { state: '*', action: [ 'output', 'param1=' ], nextState: 'frac' } ]
+        }, {
+          match: '\\overset{(...)}',
+          actions: [ { state: '*', action: [ 'output', 'param1=' ], nextState: 'overset' } ]
+        }, {
+          match: '\\underset{(...)}',
+          actions: [ { state: '*', action: [ 'output', 'param1=' ], nextState: 'underset' } ]
+        }, {
+          match: '\\underbrace{(...)}',
+          actions: [ { state: '*', action: [ 'output', 'param1=' ], nextState: 'underbrace' } ]
+        }, {
+          match: '\\color{(...)}',
+          actions: [ { state: '*', action: [ 'output', 'param1=' ], nextState: 'color' } ]
+        }, {
+          match: '\\ce{(...)}',
+          actions: [ { state: '*', action: [ 'output', 'ce' ], nextState: '1' } ]
+        }, {
+          match: '\\,',
+          actions: [ { state: '*', action: [ 'output', 'copy' ], nextState: '1' } ]
+        }, {
+          match: '\\x',
+          actions: [ { state: '*', action: [ 'output', 'copy' ], nextState: 'c0' } ]
+        }, {
+          match: 'else',
+          actions: [ { state: 'c0', action: 'copy', nextState: '1' },
+                     { state: 'c1', nextState: '0', revisit: true },
+                     { state: 'a', action: 'a to o', nextState: 'o', revisit: true },
+                     { state: 'r|rt|rd|rdt|rdq', action: [ 'output' ], nextState: '0', revisit: true },
+                     { state: '*', action: [ 'output', 'copy' ], nextState: '1' } ]
+        }
+      ];
+      //
+      // Parsing actions (e.g. store a value into a buffer) for main parser
+      //
+      that.stateMachines['ce'].actions = {
+        'o after d': function (m) {
+          var ret;
+          if (that.buffer.d.match(/^[0-9]+$/)) {
+            var tmp = that.buffer.d;
+            that.buffer.d = undefined;
+            ret = this['output']();
+            that.buffer.b = tmp;
+          } else {
+            ret = this['output']();
+          }
+          that.actions['o='](m);
+          return ret;
+        },
+        'd= kv': function (m) {
+          that.buffer.d = m;
+          that.buffer['d-type'] = 'kv';
+        },
+        'charge or bond': function (m) {
+          if (that.buffer.beginsWithBond) {
+            var ret = that.concatNotUndefined(ret, this['output']());
+            ret = that.concatNotUndefined(ret, that.actions['bond'](m, '-'));
+            return ret;
+          } else {
+            that.buffer.d = m;
+          }
+        },
+        '- after o': function (m) {
+          var e = !that.buffer.b && !that.buffer.p;
+          var n = that.match('one lowercase letter $', that.buffer.o || '');
+          var ret = that.concatNotUndefined(null, this['output']());
+          if (e && n && n.remainder === '') {
+            ret = that.concatNotUndefined(ret, { type: 'hyphen' });
+          } else {
+            ret = that.concatNotUndefined(ret, that.actions['bond'](m, '-'));
+          }
+          return ret;
+        },
+        '- after d': function (m) {
+          var c1 = !that.buffer.b && !that.buffer.p;
+          var c2 = that.match('one lowercase letter $', that.buffer.o || '');
+          var c3 = that.match('digits', that.buffer.d);
+          var ret;
+          if (c1  &&  c2  &&  c2.remainder === '') {
+            ret = that.concatNotUndefined(null, this['output']());
+            ret = that.concatNotUndefined(ret, { type: 'hyphen' });
+          } else if (c3  &&  c3.remainder === '') {
+            ret = that.concatNotUndefined(null, that.actions['d='](m));
+            ret = that.concatNotUndefined(ret, this['output']());
+          } else {
+            ret = that.concatNotUndefined(null, this['output']());
+            ret = that.concatNotUndefined(ret, that.actions['bond'](m, '-'));
+          }
+          return ret;
+        },
+        'a to o': function (m) {
+            that.buffer.o = that.buffer.a;
+            that.buffer.a = undefined;
+        },
+        'sb=true': function (m) { that.buffer.sb = true; },
+        'sb=false': function (m) { that.buffer.sb = false; },
+        'beginsWithBond=true': function (m) { that.buffer.beginsWithBond = true; },
+        'beginsWithBond=false': function (m) { that.buffer.beginsWithBond = false; },
+        'state of aggregation': function (m) {
+            m = (new MhchemParser()).parse(m, 'o');
+            return { type: 'state of aggregation', p1: m };
+        },
+        'output': function (m) {
+          if (!that.buffer.r) {
+            var ret = [];
+            if (!that.buffer.a && !that.buffer.b && !that.buffer.p &&
+             !that.buffer.o && !that.buffer.q && !that.buffer.d) {
+              ret = null;
+            } else {
+              if (that.buffer.sb) {
+                ret.push({ type: 'entitySkip' });
+              }
+              if (!that.buffer.o && !that.buffer.q && !that.buffer.d &&
+               !that.buffer.b && !that.buffer.p) {
+                that.buffer.o = (new MhchemParser()).parse(that.buffer.a, 'o');
+                that.buffer.a = undefined;
+              } else if (!that.buffer.o && !that.buffer.q && !that.buffer.d) {
+                that.buffer.o = (new MhchemParser()).parse(that.buffer.a, 'o');
+                that.buffer.d = (new MhchemParser()).parse(that.buffer.b, 'bd');
+                that.buffer.q = (new MhchemParser()).parse(that.buffer.p, 'pq');
+                that.buffer.a = that.buffer.b = that.buffer.p = undefined;
+              } else {
+                if (that.buffer.o && that.buffer['d-type']=='kv' && !that.buffer.q) {
+                  that.buffer['d-type'] = undefined;
+                }
+                that.buffer.a = (new MhchemParser()).parse(that.buffer.a, 'a');
+                that.buffer.b = (new MhchemParser()).parse(that.buffer.b, 'bd');
+                that.buffer.p = (new MhchemParser()).parse(that.buffer.p, 'pq');
+                that.buffer.o = (new MhchemParser()).parse(that.buffer.o, 'o');
+                that.buffer.d = (new MhchemParser()).parse(that.buffer.d, 'bd');
+                that.buffer.q = (new MhchemParser()).parse(that.buffer.q, 'pq');
+              }
+              ret.push({
+                type: 'chemfive',
+                a: that.buffer.a,
+                b: that.buffer.b,
+                p: that.buffer.p,
+                o: that.buffer.o,
+                q: that.buffer.q,
+                d: that.buffer.d,
+                'd-type': that.buffer['d-type']
+              });
+            }
+            that.buffer = { beginsWithBond: that.buffer.beginsWithBond };
+            return ret;
+          } else {  // r
+            if (that.buffer.rdt === 'M') {
+              that.buffer.rd = (new MhchemParser()).parse(that.buffer.rd, 'tex-math');
+            } else if (that.buffer.rdt === 'T') {
+              that.buffer.rd = [ { type: 'text', p1: that.buffer.rd } ];
+            } else {
+              that.buffer.rd = (new MhchemParser()).parse(that.buffer.rd);
+            }
+            if (that.buffer.rqt === 'M') {
+              that.buffer.rq = (new MhchemParser()).parse(that.buffer.rq, 'tex-math');
+            } else if (that.buffer.rqt === 'T') {
+              that.buffer.rq = [ { type: 'text', p1: that.buffer.rq } ];
+            } else {
+              that.buffer.rq = (new MhchemParser()).parse(that.buffer.rq);
+            }
+            ret = {
+              type: 'arrow',
+              r: that.buffer.r,
+              rd: that.buffer.rd,
+              rq: that.buffer.rq
+            };
+            that.buffer = {};
+            return ret;
+          }
+        },
+        'param1=': function (m) { that.buffer.param1 = m; },
+        'frac-output': function (m) {
+          that.buffer.param1 = (new MhchemParser()).parse(that.buffer.param1);
+          return { type: 'frac-ce', p1: that.buffer.param1, p2: (new MhchemParser()).parse(m) };
+        },
+        'overset-output': function (m) {
+          that.buffer.param1 = (new MhchemParser()).parse(that.buffer.param1);
+          return { type: 'overset', p1: that.buffer.param1, p2: (new MhchemParser()).parse(m) };
+        },
+        'underset-output': function (m) {
+          that.buffer.param1 = (new MhchemParser()).parse(that.buffer.param1);
+          return { type: 'underset', p1: that.buffer.param1, p2: (new MhchemParser()).parse(m) };
+        },
+        'underbrace-output': function (m) {
+          that.buffer.param1 = (new MhchemParser()).parse(that.buffer.param1);
+          return { type: 'underbrace', p1: that.buffer.param1, p2: (new MhchemParser()).parse(m) };
+        },
+        'color-output': function (m) {
+          var color2 = (new MhchemParser()).parse(m);
+          return { type: 'color', color1: that.buffer.param1, color2: color2 };
+        },
+        'r=': function (m) { that.buffer.r = (that.buffer.r || '') + m; },
+        'rdt=': function (m) { that.buffer.rdt = (that.buffer.rdt || '') + m; },
+        'rd=': function (m) { that.buffer.rd = (that.buffer.rd || '') + m; },
+        'rqt=': function (m) { that.buffer.rqt = (that.buffer.rqt || '') + m; },
+        'rq=': function (m) { that.buffer.rq = (that.buffer.rq || '') + m; },
+        'operator': function (m) {
+          var ret = that.concatNotUndefined(null, this['output']());
+          return that.concatNotUndefined(ret, { type: 'operator', kind: m });
+        }
+      };
+      //
+      // Transitions and actions of a parser
+      //
+      that.stateMachines['a'] = {};
+      that.stateMachines['a'].transitions = [
+        {
+          match: 'empty',
+          actions: [ { state: '*' } ]
+        }, {
+          match: '1/2$',
+          actions: [ { state: '0', action: '1/2' } ]
+        }, {
+          match: 'else',
+          actions: [ { state: '0', nextState: '1', revisit: true } ]
+        }, {
+          match: '$(...)$',
+          actions: [ { state: '*', action: 'tex-math tight', nextState: '1' } ]
+        }, {
+          match: ',',
+          actions: [ { state: '*', action: { type: 'insert', option: 'commaDecimal' } } ]
+        }, {
+          match: 'else',
+          actions: [ { state: '*', action: 'copy' } ]
+        }
+      ];
+      that.stateMachines['a'].actions = {};
+      //
+      // Transitions and actions of o parser
+      //
+      that.stateMachines['o'] = {};
+      that.stateMachines['o'].transitions = [
+        {
+          match: 'empty',
+          actions: [ { state: '*' } ]
+        }, {
+          match: '1/2$',
+          actions: [ { state: '0', action: '1/2' } ]
+        }, {
+          match: 'else',
+          actions: [ { state: '0', nextState: '1', revisit: true } ]
+        }, {
+          match: 'letters',
+          actions: [ { state: '*', action: 'rm' } ]
+        }, {
+          match: '\\x',
+          actions: [ { state: '*', action: 'copy' } ]
+        }, {
+          match: [ '${(...)}$', '$(...)$' ],
+          actions: [ { state: '*', action: 'tex-math' } ]
+        }, {
+          match: '{(...)}',
+          actions: [ { state: '*',  action: '{text}' } ]
+        }, {
+          match: 'else',
+          actions: [ { state: '*', action: 'copy' } ]
+        }
+      ];
+      that.stateMachines['o'].actions = {};
+      //
+      // Transitions and actions of text parser
+      //
+      that.stateMachines['text'] = {};
+      that.stateMachines['text'].transitions = [
+        {
+          match: 'empty',
+          actions: [ { state: '*', action: 'output' } ]
+        }, {
+          match: '\\greek',
+          actions: [ { state: '*', action: [ 'output', 'rm' ] } ]
+        }, {
+          match: '{...}',
+          actions: [ { state: 'c0', action: 'copy', nextState: 'c1' },
+                     { state: 'c1', action: 'copy', nextState: '0' },
+                     { state: '*', action: 'text=' } ]
+        }, {
+          match: [ '${(...)}$', '$(...)$' ],
+          actions: [ { state: '*', action: 'tex-math' } ]
+        }, {
+          match: '\\,',
+          actions: [ { state: '*', action: [ 'output', 'copy' ], nextState: '0' } ]
+        }, {
+          match: '\\x',
+          actions: [ { state: '*', action: [ 'output', 'copy' ], nextState: 'c0' } ]
+        }, {
+          match: 'else',
+          actions: [ { state: 'c0', action: 'copy', nextState: '0' },
+                     { state: 'c1', nextState: '0', revisit: true },
+                     { state: '*', action: 'text=' } ]
+        }
+      ];
+      that.stateMachines['text'].actions = {
+        'output': function (m) { if (that.buffer.text) {
+            var ret = { type: 'text', p1: that.buffer.text }; }
+            that.buffer = {};
+            return ret;
+        }
+      };
+      //
+      // Transitions and actions of pq parser
+      //
+      that.stateMachines['pq'] = {};
+      that.stateMachines['pq'].transitions = [
+        {
+          match: 'empty',
+          actions: [ { state: '*' } ]
+        }, {
+          match: 'state of aggregation $',
+          actions: [ { state: '*', action: 'state of aggregation' } ]
+        }, {
+          match: 'formula$',
+          actions: [ { state: '0', nextState: 'f', revisit: true } ]
+        }, {
+          match: '1/2$',
+          actions: [ { state: '0', action: '1/2' } ]
+        }, {
+          match: 'else',
+          actions: [ { state: '0', nextState: '!f', revisit: true } ]
+        }, {
+          match: [ '${(...)}$', '$(...)$' ],
+          actions: [ { state: '*', action: 'tex-math' } ]
+        }, {
+          match: '{...}',
+          actions: [ { state: 'c0', action: 'copy', nextState: 'c1' },
+                     { state: 'c1', action: 'copy', nextState: '!f' } ]
+        }, {
+          match: '{(...)}',
+          actions: [ { state: '*', action: 'text' } ]
+        }, {
+          match: 'a-z',
+          actions: [ { state: 'f',  action: 'tex-math' } ]
+        }, {
+          match: 'letters',
+          actions: [ { state: '*', action: 'rm' } ]
+        }, {
+          match: '-9.,9',
+          actions: [ { state: '*', action: '9,9'  } ]
+        },{
+          match: ',',
+          actions: [ { state: '*', action: { type: 'insert', option: 'comma enumeration small' } } ]
+        }, {
+          match: '\\ce{(...)}',
+          actions: [ { state: '*', action: 'ce' } ]
+        }, {
+          match: '\\,',
+          actions: [ { state: '*', action: 'copy', nextState: '0' } ]
+        }, {
+          match: '\\x',
+          actions: [ { state: '!f', action: 'copy', nextState: 'c0' } ]
+        }, {
+          match: 'else',
+          actions: [ { state: 'c0', action: 'copy', nextState: '0' },
+                     { state: 'c1', nextState: '0', revisit: true },
+                     { state: '*', action: 'copy' } ]
+        }
+      ];
+      that.stateMachines['pq'].actions = {
+        'state of aggregation': function (m) {
+            m = (new MhchemParser()).parse(m, 'o');
+            return { type: 'state of aggregation subscript', p1: m };
+        }
+      };
+      //
+      // Transitions and actions of bd parser
+      //
+      that.stateMachines['bd'] = {};
+      that.stateMachines['bd'].transitions = [
+        {
+          match: 'empty',
+          actions: [ { state: '*' } ]
+        }, {
+          match: 'oxidation$',
+          actions: [ { state: '0', action: 'oxidation' } ]
+        }, {
+          match: 'else',
+          actions: [ { state: '0', nextState: '1', revisit: true } ]
+        }, {
+          match: '-9.,9 no missing 0',
+          actions: [ { state: '*', action: '9,9' } ]
+        }, {
+          match: '.',
+          actions: [ { state: '*', action: { type: 'insert', option: 'electron dot' }, nextState: '1' } ]
+        }, {
+          match: 'a-z',
+          actions: [ { state: '*',  action: 'tex-math' } ]
+        }, {
+          match: 'letters',
+          actions: [ { state: '*',  action: 'rm' } ]
+        }, {
+          match: [ '${(...)}$', '$(...)$' ],
+          actions: [ { state: '*', action: 'tex-math' } ]
+        }, {
+          match: '{...}',
+          actions: [ { state: 'c0', action: 'copy', nextState: 'c1' },
+                     { state: 'c1', action: 'copy', nextState: '0' } ]
+        }, {
+          match: '{(...)}',
+          actions: [ { state: '*', action: 'text' } ]
+        }, {
+          match: '\\ce{(...)}',
+          actions: [ { state: '*', action: 'ce' } ]
+        }, {
+          match: '\\,',
+          actions: [ { state: '*', action: 'copy' } ]
+        }, {
+          match: '\\x',
+          actions: [ { state: '*', action: 'copy', nextState: 'c0' } ]
+        }, {
+          match: 'else',
+          actions: [ { state: 'c0', action: 'copy', nextState: '0' },
+                     { state: 'c1', nextState: '0', revisit: true },
+                     { state: '*', action: 'copy' } ]
+        }
+      ];
+      that.stateMachines['bd'].actions = {
+        'oxidation': function (m) { return { type: 'oxidation', p1: m }; }
+      };
+      //
+      // Transitions and actions of tex-math parser
+      //
+      that.stateMachines['tex-math'] = {};
+      that.stateMachines['tex-math'].transitions = [
+        {
+          match: 'empty',
+          actions: [ { state: '*', action: 'output' } ]
+        }, {
+          match: '\\ce{(...)}',
+          actions: [ { state: '*', action: [ 'output', 'ce' ] } ]
+        }, {
+          match: [ '{...}', '\\,', '\\x' ],
+          actions: [ { state: '*', action: 'o=' } ]
+        }, {
+          match: 'else',
+          actions: [ { state: '*', action: 'o=' } ]
+        }
+      ];
+      that.stateMachines['tex-math'].actions = {
+        'output': function (m) {
+          if (that.buffer.o) {
+            var ret = { type: 'tex-math', p1: that.buffer.o };
+            that.buffer = {};
+            return ret;
+          }
+          return null;
+        }
+      };
+      //
+      // Transitions and actions of tex-math-tight parser
+      //
+      that.stateMachines['tex-math tight'] = {};
+      that.stateMachines['tex-math tight'].transitions = [
+        {
+          match: 'empty',
+          actions: [ { state: '*', action: 'output' } ]
+        }, {
+          match: '\\ce{(...)}',
+          actions: [ { state: '*', action: [ 'output', 'ce' ] } ]
+        }, {
+          match: [ '{...}', '\\,', '\\x' ],
+          actions: [ { state: '*', action: 'o=' } ]
+        }, {
+          match: [ '-', '+' ],
+          actions: [ { state: '*', action: 'tight operator' } ]
+        }, {
+          match: 'else',
+          actions: [ { state: '*', action: 'o=' } ]
+        }
+      ];
+      that.stateMachines['tex-math tight'].actions = {
+        'tight operator': function (m) { that.buffer.o = (that.buffer.o || '') + '{'+m+'}'; },
+        'output': function (m) {
+          if (that.buffer.o) {
+            var ret = { type: 'tex-math', p1: that.buffer.o };
+            that.buffer = {};
+            return ret;
+          }
+          return null;
+        }
+      };
+      //
+      // Transitions and actions of 9,9 parser
+      //
+      that.stateMachines['9,9'] = {};
+      that.stateMachines['9,9'].transitions = [
+        {
+          match: 'empty',
+          actions: [ { state: '*' } ]
+        }, {
+          match: ',',
+          actions: [ { state: '*', action: 'comma' } ]
+        }, {
+          match: 'else',
+          actions: [ { state: '*', action: 'copy' } ]
+        }
+      ];
+      that.stateMachines['9,9'].actions = {
+        'comma': function (m) { return { type: 'commaDecimal' }; }
+      };
+
+      return that;
     },
 
     //
-    //  Check if the string matches a regular expression
-    //    and move past it if so, returning the match
+    // Take MhchemParser output and convert it to TeX
+    // (recursive)
     //
-    Match: function (regex) {
-      var match = regex.exec(this.string.substr(this.i));
-      if (match) {match = match[0]; this.i += match.length}
-      return match;
-    },
-    
-    //
-    //  Find a particular character, skipping over braced groups
-    //
-    Find: function (c) {
-      var m = this.string.length, i = this.i, braces = 0;
-      while (this.i < m) {
-        var C = this.string.charAt(this.i++);
-        if (C === c && braces === 0) {return this.string.substr(i,this.i-i-1)}
-        if (C === "{") {braces++} else
-        if (C === "}") {
-          if (braces) {braces--}
-          else {
-            TEX.Error(["ExtraCloseMissingOpen","Extra close brace or missing open brace"])
+    texify: function texify(input) {
+      if (!input) { return input; }
+      var types = {
+        'chemfive': function (buf) {
+          var res = '';
+          buf.a = texify(buf.a);
+          buf.b = texify(buf.b);
+          buf.p = texify(buf.p);
+          buf.o = texify(buf.o);
+          buf.q = texify(buf.q);
+          buf.d = texify(buf.d);
+          //
+          // a
+          //
+          if (buf.a) { res += buf.a + '\\,'; }
+          //
+          // b and p
+          //
+          if (buf.b || buf.p) {
+            res += '\\mskip1.5mu ';
+            res += '{\\vphantom{X}}';
+            res += '^{\\hphantom{'+(buf.b||'')+'}}_{\\hphantom{'+(buf.p||'')+'}}';
+            res += '\\mskip-1mu ';
+            res += '{\\vphantom{X}}';
+            res += '^{\\smash[t]{\\vphantom{2}}\\llap{'+(buf.b||'')+'}}';
+            res += '_{\\vphantom{2}\\llap{\\smash[t]{'+(buf.p||'')+'}}}';
           }
+          //
+          // o
+          //
+          if (buf.o) { res += buf.o; }
+          //
+          // q and d
+          //
+          if (buf.d  &&  buf['d-type'] === 'kv') {
+            res += '{\\vphantom{X}}';
+            res += '^{'+buf.d+'}';
+          }
+          if (buf.q) {
+            res += '{\\vphantom{X}}';
+            res += '_{\\smash[t]{'+buf.q+'}}';
+          }
+          if (buf.d  &&  buf['d-type'] !== 'kv') {
+            res += '{\\vphantom{X}}';
+            res += '^{'+buf.d+'}';
+          }
+          return res;
+        },
+        'rm': function (buf) { return '\\mathrm{'+buf.p1+'}'; },
+        'text': function (buf) { return '\\text{'+buf.p1+'}'; },
+        'oxidation': function (buf) { return '\\mathrm{'+buf.p1+'}'; },
+        'state of aggregation': function (buf) { return '\\mskip3mu '+texify(buf.p1); },
+        'state of aggregation subscript': function (buf) { return '\\mskip2mu '+texify(buf.p1)+'\\mskip1mu '; },
+        'bond': function (buf) {
+          var bonds = {
+            '-': '{-}',
+            '1': '{-}',
+            '=': '{=}',
+            '2': '{=}',
+            '#': '{\\equiv}',
+            '3': '{\\equiv}',
+            '~': '{\\tripledash}',
+            '~-': '{\\begin{CEstack}{}\\tripledash\\\\-\\end{CEstack}}',
+            '~=': '{\\raise2mu {\\begin{CEstack}{}\\tripledash\\\\-\\\\-\\end{CEstack}}}',
+            '~--': '{\\raise2mu {\\begin{CEstack}{}\\tripledash\\\\-\\\\-\\end{CEstack}}}',
+            '-~-': '{\\raise2mu {\\begin{CEstack}{}-\\\\\\tripledash\\\\-\\end{CEstack}}}',
+            '...': '{{\\cdot}{\\cdot}{\\cdot}}',
+            '....': '{{\\cdot}{\\cdot}{\\cdot}{\\cdot}}',
+            '->': '{\\rightarrow}',
+            '<-': '{\\leftarrow}'
+          };
+          if (!bonds[buf.kind]) {
+            throw ['MhchemErrorUnknownBond', 'mhchem Error – Unknown bond type'];
+          }
+          return bonds[buf.kind];
+        },
+        'frac': function (buf) {
+            var c = '\\frac{' + buf.p1 + '}{' + buf.p2 + '}';
+            return '\\mathchoice{\\textstyle'+c+'}{'+c+'}{'+c+'}{'+c+'}';
+         },
+        'tex-math': function (buf) { return buf.p1 + '{}'; },
+        'frac-ce': function (buf) {
+          return '\\frac{' + texify(buf.p1) + '}{' + texify(buf.p2) + '}';
+        },
+        'overset': function (buf) {
+          return '\\overset{' + texify(buf.p1) + '}{' + texify(buf.p2) + '}';
+        },
+        'underset': function (buf) {
+          return '\\underset{' + texify(buf.p1) + '}{' + texify(buf.p2) + '}';
+        },
+        'underbrace': function (buf) {
+          return '\\underbrace{' + texify(buf.p1) + '}_{' + texify(buf.p2) + '}';
+        },
+        'color': function (buf) {
+          return '\\color{' + buf.color1 + '}{' + texify(buf.color2) + '}';
+        },
+        'arrow': function (buf) {
+          var arrows = {
+            '->': 'rightarrow',
+            '<-': 'leftarrow',
+            '<->': 'leftrightarrow',
+            '<-->': 'leftrightarrows',
+            '<=>': 'rightleftharpoons',
+            '<=>>': 'Rightleftharpoons',
+            '<<=>': 'Leftrightharpoons'
+          };
+          buf.rd = texify(buf.rd);
+          buf.rq = texify(buf.rq);
+          var arrow = arrows[buf.r];
+          if (buf.rd || buf.rq) {
+            if (buf.rq) {arrow += "[{"+buf.rq+"}]";}
+            arrow += "{"+buf.rd+"}";
+            arrow = ' \\mkern3mu\\mathrel{\\x'+arrow+'}\\mkern3mu ';
+          } else {
+            arrow = ' \\mkern3mu\\long'+arrow+'\\mkern3mu ';
+          }
+          return arrow;
+        },
+        'operator': function(buf) {
+          var operators = {
+            '+': ' \\mkern3mu+\\mkern3mu ',
+            '-': ' \\mkern3mu-\\mkern3mu ',
+            '=': ' \\mkern3mu=\\mkern3mu ',
+            '\\pm': ' \\mkern3mu\\pm\\mkern3mu ',
+            '$\\pm$': ' \\mkern3mu\\pm\\mkern3mu ',
+            'v': ' \\downarrow{} ',
+            '(v)': ' \\downarrow{} ',
+            '^': ' \\uparrow{} ',
+            '(^)': ' \\uparrow{} '
+          };
+          return operators[buf.kind];
+        }
+      };
+      var entities = {
+        'space': ' ',
+        'entitySkip': '\\,',
+        'commaDecimal': '{,}',
+        'comma enumeration': '{,}\\mkern3mu ',
+        'comma enumeration small': '{,}\\mkern1mu ',
+        'hyphen': '\\text{-}',
+        'addition compound': '\\,{\\cdot}\\,',
+        'electron dot': '\\mkern1mu \\bullet\\mkern1mu ',
+        '^': 'uparrow',
+        'v': 'downarrow'
+      };
+
+      var res = '';
+      for (var i=0; i<input.length; i++) {
+        if (typeof input[i] === 'string') {
+          res += input[i];
+        } else if (types[input[i].type]) {
+          res += types[input[i].type](input[i]);
+        } else if (entities[input[i].type]) {
+          res += entities[input[i].type];
+        } else {
+          throw ['InternalMhchemErrorUnknownMhchemParserOutput', 'Internal mhchem Error – Unknown MhchemParser output'];
         }
       }
-      if (braces) {TEX.Error(["MissingCloseBrace","Missing close brace"])}
-      TEX.Error(["NoClosingChar","Can't find closing %1",c]);
+      return res;
     }
     
   });
@@ -388,8 +1226,6 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
       //  Set up the macros for chemistry
       //
       ce:   'CE',
-      cf:   'CE',
-      cee:  'CE',
       
       //
       //  Make these load AMSmath package (redefined below when loaded)
@@ -409,12 +1245,6 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
       //  
       hyphen: ["Macro","\\text{-}"],
       
-      //
-      //  Handle prescripts and none
-      //
-      CEprescripts: "CEprescripts",
-      CEnone: "CEnone",
-
       //
       //  Needed for \bond for the ~ forms
       //
@@ -464,22 +1294,6 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
       var arg = this.GetArgument(name);
       var tex = CE(arg).Parse();
       this.string = tex + this.string.substr(this.i); this.i = 0;
-    },
-    
-    //
-    //  Implements \CEprescripts{presub}{presup}{base}{sub}{sup}
-    //
-    CEprescripts: function (name) {
-      var presub = this.ParseArg(name),
-          presup = this.ParseArg(name),
-          base = this.ParseArg(name),
-          sub = this.ParseArg(name),
-          sup = this.ParseArg(name);
-      var MML = MathJax.ElementJax.mml;
-      this.Push(MML.mmultiscripts(base,sub,sup,MML.mprescripts(),presub,presup));
-    },
-    CEnone: function (name) {
-      this.Push(MathJax.ElementJax.mml.none());
     }
     
   });


### PR DESCRIPTION
This is a "request for discussion" pull-request, because there is still some fine-tuning I'd like to do.

I am the inventor and author of the LaTeX package mhchem. MathJax includes an mhchem implementation that, over time, got a little bit disconnected from the LaTeX package. Having talked to dpvc and pkra, I'd like to take over maintenance of MathJax/mhchem and bring it up-to-date.

It resulted in a complete rewrite of the core part. This is my first take. Please discuss.

There are some inconsistencies. The most notable change is the switch to staggered charges, as has become the standard in recent years (IUPAC, many publishers). But there are a few other differences on close inspection. For testing and comparison, I downloaded 43.5k usages of \ce from chemistry.stackexchange.com. I went through 2k of them manually and checked the rest by script. A few hundred of these would break visually and I already fixed them on StackExchange. (Most of them were mere misuse of \ce, using it for non-chemical stuff.)

One thing, that still bothers me, are the reaction arrows. I consider it an important feature of mhchem, to have very readable input, not just nice output. Therefore, I would like to enforce a space before and after an reaction arrow. What keeps me from doing this, are the 500 or so StackExchange posts that I would need to edit. Still thinking. I don't know of any other large consumer of mhchem and would like to get it just right, just before others, like Wikipedia catch on.

As for this discussion, please comment on the code (quality, compatibility, style). Please discuss whether this should (with some incompatibilities!) replace the current mhchem extension or if this should become a 3rd-party extension.

BTW. It was not only a one-way street to bring LaTeX/mhchem features to MathJax/mhchem. I also have a list of 10 or so use cases, that I saw people using with MathJax, that I want to backport to LaTeX.