### PR TITLE
Fix TeX.Environment() to use the correct end environment.

### DIFF
--- a/unpacked/extensions/TeX/newcommand.js
+++ b/unpacked/extensions/TeX/newcommand.js
@@ -258,7 +258,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
   });
   
   TEX.Environment = function (name) {
-    TEXDEF.environment[name] = ['BeginEnv','EndEnv'].concat([].slice.call(arguments,1));
+    TEXDEF.environment[name] = ['BeginEnv',[null,'EndEnv']].concat([].slice.call(arguments,1));
     TEXDEF.environment[name].isUser = true;
   }
 


### PR DESCRIPTION
There is no issue number for this.  It turned up when I was checking another bug, but was unrelated to it.  You are supposed to be able to use

`MathJax.InputJax.TeX.Environment(name,prefix,suffix,n,default)`

(after loading the TeX `newcommand` extension) in order to define a new command, where `prefix` is the TeX code to insert at the beginning of the environment, `suffix` is the TeX to insert at the end, `n` is the number of arguments required for the environment, and `default` is the default for the argument.  The `n` and `default` are not required.

This works as advertised, except for one thing:  if the `prefix` includes a `\begin{...}` and the `suffix` includes an `\end{...}`, MathJax issues an error about the nesting being wrong.  With this fix, the begin and end work properly.  E.g., 

```
MathJax.InputJax.TeX.Environment("nested","\\begin{matrix}","\\end{matrix}");
```

would cause `\begin{nested} a& b \end{nested}` to produce the message '\begin{matrix} ended by \end{nested}` without the patch.  With the patch, you should get a matrix as expected.