### PR TITLE
Fix problems from puzzling.SE

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -2182,7 +2182,7 @@ MathJax.Hub = {
         //
         //  Check if already processed or needs processing
         //
-        if (!script.MathJax || script.MathJax.state === STATE.PROCESSED) {state.i++; continue};
+        if (!script.parentNode || !script.MathJax || script.MathJax.state === STATE.PROCESSED) {state.i++; continue};
         if (!script.MathJax.elementJax || script.MathJax.state === STATE.UPDATE) {
           this.checkScriptSiblings(script);                 // remove preJax/postJax etc.
           var type = script.type.replace(/ *;(.|\s)*/,"");  // the input jax type
@@ -2286,7 +2286,7 @@ MathJax.Hub = {
         //  Check that there is an element jax
         //
         script = state.scripts[state.i];
-        if (!script || !script.MathJax || script.MathJax.error) {state.i++; continue}
+        if (!script || !script.parentNode || !script.MathJax || script.MathJax.error) {state.i++; continue}
         var jax = script.MathJax.elementJax; if (!jax) {state.i++; continue}
         //
         //  Call the output Jax's Process method (which will be its Translate()

--- a/unpacked/extensions/fast-preview.js
+++ b/unpacked/extensions/fast-preview.js
@@ -100,7 +100,7 @@
     //  and call the PreviewHTML output jax to create the preview
     //
     Preview: function (data) {
-      if (!this.Active()) return;
+      if (!this.Active() || !data.script.parentNode) return;
       var preview = data.script.MathJax.preview || data.script.previousSibling;
       if (!preview || preview.className !== MathJax.Hub.config.preRemoveClass) {
         preview = HTML.Element("span",{className:MathJax.Hub.config.preRemoveClass});

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -745,9 +745,9 @@
       //
       for (i = state.HTMLCSSlast, m = state.HTMLCSSeqn; i < m; i++) {
         script = scripts[i];
-        if (script && script.MathJax.elementJax) {
-          var div = script.MathJax.elementJax.HTMLCSS.div;
-          div.className = div.className.split(/ /)[0];
+        if (script && script.parentNode && script.MathJax.elementJax) {
+          var div = (script.MathJax.elementJax.HTMLCSS||{}).div;
+          if (div) {div.className = div.className.split(/ /)[0]}
           if (script.MathJax.preview) {script.MathJax.preview.innerHTML = ""}
         }
       }
@@ -756,7 +756,7 @@
       //
       for (i = state.HTMLCSSlast, m = state.HTMLCSSeqn; i < m; i++) {
         script = scripts[i];
-        if (script && script.MathJax.elementJax) {
+        if (script && script.parentNode && script.MathJax.elementJax) {
           jax = script.MathJax.elementJax; this.getMetrics(jax);
           jax.root.toHTML(jax.HTMLCSS.span,jax.HTMLCSS.div,this.PHASE.II);
         }
@@ -766,7 +766,7 @@
       //
       for (i = state.HTMLCSSlast, m = state.HTMLCSSeqn; i < m; i++) {
         script = scripts[i];
-        if (script && script.MathJax.elementJax) {
+        if (script && script.parentNode && script.MathJax.elementJax) {
           //
           //  Finish the math with its measured size (toHTML phase III)
           //

--- a/unpacked/jax/output/PlainSource/jax.js
+++ b/unpacked/jax/output/PlainSource/jax.js
@@ -65,7 +65,7 @@
         //  Remove any existing output
         //
         prev = script.previousSibling;
-        if (prev && String(prev.className).match(/^MathJax_PlainSource(_Display)?( MathJax_Processing)?$/)) {
+        if (prev && String(prev.className).match(/^MathJax(_PlainSource)?(_Display)?( MathJax_Process(ing|ed))?$/)) {
           prev.parentNode.removeChild(prev);
         }
         //

--- a/unpacked/jax/output/PreviewHTML/jax.js
+++ b/unpacked/jax/output/PreviewHTML/jax.js
@@ -185,7 +185,7 @@
         //  Remove any existing output
         //
         prev = script.previousSibling;
-        if (prev && String(prev.className).match(/^MathJax_PHTML(_Display)?( MathJax_Processing)?$/))
+        if (prev && String(prev.className).match(/^MathJax(_PHTML)?(_Display)?( MathJax_Process(ing|ed))?$/))
           {prev.parentNode.removeChild(prev)}
         //
         //  Add the span, and a div if in display mode,

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -207,7 +207,7 @@
         //  Remove any existing output
         //
         prev = script.previousSibling;
-        if (prev && String(prev.className).match(/^MathJax(_SVG)?(_Display)?( MathJax(_SVG)?_Processing)?$/))
+        if (prev && String(prev.className).match(/^MathJax(_SVG)?(_Display)?( MathJax(_SVG)?_Process(ing|ed))?$/))
           {prev.parentNode.removeChild(prev)}
         //
         //  Add the span, and a div if in display mode,


### PR DESCRIPTION
This fixes some places where the removal of DOM elements while MathJax is running could cause MathJax to stop processing, or to leave duplicate copies of the typeset math in place.  Resolves issue #1384.