### PR TITLE
Fix problem with container width in SVG when math is scaled.

### DIFF
--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -249,7 +249,7 @@
         test = script.previousSibling; div = test.previousSibling;
         jax = script.MathJax.elementJax; if (!jax) continue;
         ex = test.firstChild.offsetHeight/60;
-        cwidth = div.previousSibling.firstChild.offsetWidth;
+        cwidth = div.previousSibling.firstChild.offsetWidth / this.config.scale * 100;
         if (relwidth) {maxwidth = cwidth}
         if (ex === 0 || ex === "NaN") {
           // can't read width, so move to hidden div for processing


### PR DESCRIPTION
If the scaling factor for all math (in the math menu or via configuration) is not 100%, the SVG container width would be incorrectly scaled as well.  This sets the size correctly so that the scaled SVG element will be the correct width when there are equation numbers, or for line breaking.  Resolves issue #1422.