### PR TITLE
Improve getNode() so that is finds the correct node. #1447

### DIFF
--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -337,19 +337,28 @@
     setScript: HTML.setScript,
     
     //
-    //  Look through the children of a node for one with the given type
-    //  but don't step into child nodes that are from MathML elements
-    //  themselves (they will have IDs).
+    //  Look through the direct children of a node for one with the given
+    //  type (but if the node has intervening containers for its children,
+    //  step into them; note that elements corresponding to MathML nodes
+    //  will have id's so we don't step into them).
+    //  
+    //  This is used by munderover and msubsup to locate their child elements
+    //  when they are part of an embellished operator that is being stretched.
+    //  We don't use querySelector because we want to find only the direct child
+    //  nodes, not nodes that might be nested deeper in the tree (see issue #1447).
     //
     getNode: function (node,type) {
-      var name = RegExp("\\b"+type+"\\b");
-      for (var i = 0, m = node.childNodes.length; i < m; i++) {
-        var child = node.childNodes[i];
-        if (name.test(child.className)) return child;
-        if (child.id == null) return this.getNode(child,type);
+      while (node && node.childNodes.length === 1 && node.firstChild.id == null)
+        node = node.firstChild;
+      if (node) {
+        var name = RegExp("\\b"+type+"\\b");
+        for (var i = 0, m = node.childNodes.length; i < m; i++) {
+          var child = node.childNodes[i];
+          if (name.test(child.className)) return child;
+        }
       }
+      return null;
     },
-
 
     /********************************************/
     

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -336,34 +336,20 @@
     ucMatch: HTML.ucMatch,
     setScript: HTML.setScript,
     
-    getNodesByClass: (document.getElementsByClassName ? 
-      function (node,type) {return node.getElementsByClassName(type)} :
-      function (node,type) {
-        var NODES = [];
-        var nodes = node.getElementsByTagName("span");
-        var name = RegExp("\\b"+type+"\\b");
-        for (var i = 0, m = nodes.length; i < m; i++) {
-          if (name.test(nodes[i].className)) NODES.push = nodes[i];
-        }
-        return NODES;
-      }
-    ),
+    //
+    //  Look through the children of a node for one with the given type
+    //  but don't step into child nodes that are from MathML elements
+    //  themselves (they will have IDs).
+    //
     getNode: function (node,type) {
-      var nodes = this.getNodesByClass(node,type);
-      if (nodes.length === 1) return nodes[0];
-      var closest = nodes[0], N = this.getNodeDepth(node,closest);
-      for (var i = 1, m = nodes.length; i < m; i++) {
-        var n = this.getNodeDepth(node,nodes[i]);
-        if (n < N) {closest = nodes[i]; N = n}
+      var name = RegExp("\\b"+type+"\\b");
+      for (var i = 0, m = node.childNodes.length; i < m; i++) {
+        var child = node.childNodes[i];
+        if (name.test(child.className)) return child;
+        if (child.id == null) return this.getNode(child,type);
       }
-      return closest;
     },
-    getNodeDepth: function (parent,node) {
-      var n = 0;
-      while (node && node !== parent) {node = node.parentNode; n++}
-      return n;
-    },
-    
+
 
     /********************************************/
     


### PR DESCRIPTION
Improves `getNode()` so that it doesn't find elements inside nodes that come from other MathML nodes (those with IDs).  Resolves issue #1447.  See that issue for examples that cause the problem.