### PR TITLE
Make sure 0 remains 0 when rounding to pixels (plus a bit).

### DIFF
--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -1007,8 +1007,8 @@
       return m.toFixed(3).replace(/\.?0+$/,"") + "em";
     },
     EmRounded: function (m) {
-      m = (Math.round(m*HTMLCSS.em)+.05)/HTMLCSS.em;
       if (Math.abs(m) < .0006) {return "0em"}
+      m = (Math.round(m*HTMLCSS.em)+.05)/HTMLCSS.em;
       return m.toFixed(3).replace(/\.?0+$/,"") + "em";
     },
     unEm: function (m) {
@@ -2937,7 +2937,9 @@
           //    Add the width to the span (outside the MathJax class, so uses outer em size,
           //    which makes it work even when minimum font size is in effect).
           //
-          span.style.width = HTMLCSS.Em(Math.max(0,Math.round(math.bbox.w*this.em)+.25)/HTMLCSS.outerEm);
+          var W = math.bbox.w;
+          if (Math.abs(W) < .006) W = 0; else W = Math.max(0,Math.round(W*this.em)+.25);
+          span.style.width = HTMLCSS.EmRounded(W/HTMLCSS.outerEm);
           span.style.display = "inline-block";
           //
           //  Adjust bbox to match outer em-size


### PR DESCRIPTION
Make sure rounded pixel values (which have a slight bit extra added to them) don't have the extra added to them when they are near 0.  Resolves issue #1452.