### PR TITLE
Bubble percentage widths up while line breaking in CHTML.

### DIFF
--- a/unpacked/jax/output/CommonHTML/autoload/multiline.js
+++ b/unpacked/jax/output/CommonHTML/autoload/multiline.js
@@ -348,6 +348,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
         //
         var node = this.CHTMLnodeElement();
         line.appendChild(node);
+        if (this.CHTML.pwidth && !line.style.width) line.style.width = this.CHTML.pwidth;
         //
         //  If it is last, remove right margin
         //  If it is first, remove left margin


### PR DESCRIPTION
This fixes the multiple-tagged-equationwith-line-breaks issue that Peter reported in #1441 by making sure the line box gets `width:100%` when the line contains an item with 100% width.