### PR TITLE
Make sure resetEquationNumbers is always defined.

### DIFF
--- a/unpacked/jax/input/TeX/config.js
+++ b/unpacked/jax/input/TeX/config.js
@@ -45,7 +45,9 @@ MathJax.InputJax.TeX = MathJax.InputJax({
       formatURL:    function (id) {return '#'+escape(id)},
       useLabelIds:  true
     }
-  }
+  },
+  
+  resetEquationNumbers: function () {}  // filled in by AMSmath extension
 });
 MathJax.InputJax.TeX.Register("math/tex");
 


### PR DESCRIPTION
Add a dummy `resetEquationNumbers()` function that is replaced by AMS.  This makes sure the method is always available (when the TeX input jax is loaded), even if there is no TeX on the page, or AMSmath isn't loaded.  Resolves issue #1419.