### PR TITLE
Fix problem with two background images in Webkit

### DIFF
--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -483,7 +483,7 @@
 
       // Used in preTranslate to get linebreak width
       this.linebreakSpan = this.Element("span",null,
-        [["hr",{style: {width:"100%", size:1, padding:0, border:0, margin:0}}]]);
+        [["hr",{style: {display:"inline-block", width:"100%", size:1, padding:0, border:0, margin:0}}]]);
 
       // Set up styles and preload web fonts
       return AJAX.Styles(this.config.styles,["InitializeHTML",this]);

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -167,7 +167,7 @@
 
       // Used in preTranslate to get linebreak width
       this.linebreakSpan = HTML.Element("span",null,
-        [["hr",{style: {width:"auto", size:1, padding:0, border:0, margin:0}}]]);
+        [["hr",{style: {display:"inline-block", width:"auto", size:1, padding:0, border:0, margin:0}}]]);
 
       // Set up styles
       return AJAX.Styles(this.config.styles,["InitializeSVG",this]);


### PR DESCRIPTION
Resolves issue #1466
- workaround for issue 1466 as default display:block makes Webkit browsers to render second image and not delete it