### PR TITLE
Catch IE8 errors with inserting MathML from AssistiveMML extension. #1477

### DIFF
--- a/unpacked/extensions/AssistiveMML.js
+++ b/unpacked/extensions/AssistiveMML.js
@@ -128,7 +128,7 @@
             className: "MJX_Assistive_MathML"
               + (jax.root.Get("display") === "block" ? " MJX_Assistive_MathML_Block" : "")
           });
-          span.innerHTML = mml;
+          try {span.innerHTML = mml} catch (err) {}
           frame.style.position = "relative";
           frame.setAttribute("role","presentation");
           frame.firstChild.setAttribute("aria-hidden","true");


### PR DESCRIPTION
Since there is no reader that can handle this with IE8 anyway, there isn't much point in trying to figure out whatever bug is the source of this error.  Resolves issue #1477.