### PR TITLE
Mark accented operators as not having movable limits.  #1469.

### DIFF
--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -1433,6 +1433,8 @@
       var def = {accent: true}; if (this.stack.env.font) {def.mathvariant = this.stack.env.font}
       var mml = this.mmlToken(MML.mo(MML.entity("#x"+accent)).With(def));
       mml.stretchy = (stretchy ? true : false);
+      var mo = (c.isEmbellished() ? c.CoreMO() : c);
+      if (mo.isa(MML.mo)) mo.movablelimits = false;
       this.Push(MML.TeXAtom(MML.munderover(c,null,mml).With({accent: true})));
     },
     


### PR DESCRIPTION
This makes sure the base of an munderover for an accented character doesn't have movablelimits (even if the operator dictionary has movablelimits by default).  This makes the accent work properly in in-line mode.  Resolves issue #1469.