### PR TITLE
Allow line breaks within TeXAtom elements  Resolves issue #1449.

### DIFF
--- a/unpacked/jax/element/mml/jax.js
+++ b/unpacked/jax/element/mml/jax.js
@@ -1463,6 +1463,7 @@ MathJax.ElementJax.mml.Augment({
   
   MML.TeXAtom = MML.mbase.Subclass({
     type: "texatom",
+    linebreakContainer: true,
     inferRow: true, notParent: true,
     texClass: MML.TEXCLASS.ORD,
     Core: MML.mbase.childCore,


### PR DESCRIPTION
Since TeXAtoms are basically mrows with additional properties, it makes sense to allow line breaks.