### PR TITLE
Make getJaxForMath() work even during chunking.

### DIFF
--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -794,7 +794,7 @@
     },
     
     getJaxFromMath: function (math) {
-      if (math.parentNode.className === "MathJax_Display") {math = math.parentNode}
+      if (math.parentNode.className.match(/MathJax_Display/)) {math = math.parentNode}
       do {math = math.nextSibling} while (math && math.nodeName.toLowerCase() !== "script");
       return HUB.getJaxFor(math);
     },

--- a/unpacked/jax/output/PlainSource/jax.js
+++ b/unpacked/jax/output/PlainSource/jax.js
@@ -141,7 +141,7 @@
     postTranslate: function(state) {},
 
     getJaxFromMath: function(math) {
-      if (math.parentNode.className === "MathJax_PlainSource_Display") math = math.parentNode;
+      if (math.parentNode.className.match(/MathJax_PlainSource_Display/)) math = math.parentNode;
       do {math = math.nextSibling} while (math && math.nodeName.toLowerCase() !== "script");
       return HUB.getJaxFor(math);
     },

--- a/unpacked/jax/output/PreviewHTML/jax.js
+++ b/unpacked/jax/output/PreviewHTML/jax.js
@@ -276,7 +276,7 @@
     },
 
     getJaxFromMath: function (math) {
-      if (math.parentNode.className === "MathJax_PHTML_Display") {math = math.parentNode}
+      if (math.parentNode.className.match(/MathJax_PHTML_Display/)) {math = math.parentNode}
       do {math = math.nextSibling} while (math && math.nodeName.toLowerCase() !== "script");
       return HUB.getJaxFor(math);
     },

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -413,7 +413,7 @@
     },
 
     getJaxFromMath: function (math) {
-      if (math.parentNode.className === "MathJax_SVG_Display") {math = math.parentNode}
+      if (math.parentNode.className.match(/MathJax_SVG_Display/)) {math = math.parentNode}
       do {math = math.nextSibling} while (math && math.nodeName.toLowerCase() !== "script");
       return HUB.getJaxFor(math);
     },


### PR DESCRIPTION
Make `getJaxForMath()` work even during chunking in all output modes.  (The chunking code adds `MathJax_Processed` to the class, so we need to search for the class we need, not check if the class is equal to it.)

Resolves issue mathjax/MathJax-RespEq#119.