### PR TITLE
Don't add a 'src' attribute (<image> uses href, not src)

### DIFF
--- a/unpacked/jax/output/SVG/autoload/mglyph.js
+++ b/unpacked/jax/output/SVG/autoload/mglyph.js
@@ -82,7 +82,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
         } else {
           var mu = this.SVGgetMu(svg);
           svg.Add(BBOX.MGLYPH(this.img.img,values.width,values.height,values.valign,mu,
-                              {src:values.src, alt:values.alt, title:values.alt}));
+                              {alt:values.alt, title:values.alt}));
         }
       }
       svg.Clean();


### PR DESCRIPTION
The `src` attribute is no valid on an `<image>` tag in SVG.  It is the `href` attribute (added in the `BBOX.MGLYPH()` function) that actually does the linking to the image source.