### PR TITLE
Fix problems with \middle.  #1023

### DIFF
--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -1335,9 +1335,11 @@
     
     Middle: function (name) {
       var delim = this.GetDelimiter(name);
+      this.Push(MML.TeXAtom().With({texClass:MML.TEXCLASS.CLOSE}));
       if (this.stack.Top().type !== "left")
         {TEX.Error(["MisplacedMiddle","%1 must be within \\left and \\right",name])}
       this.Push(MML.mo(delim).With({stretchy:true}));
+      this.Push(MML.TeXAtom().With({texClass:MML.TEXCLASS.OPEN}));
     },
     
     NamedFn: function (name,id) {


### PR DESCRIPTION
Surround \middle with OPEN and CLOSE TeXAtoms, so that the spacing will be consistent with TeX's version (e.g., \mathrel{}\middle|\mathrel{} will produce the right spacing).  As a side effect, this resolves the problem with the quotes, sot this resolves issue #1023.