### PR TITLE
Make CHTML mglyph scale image size by hand.  mathjax/MathJax-node#241

### DIFF
--- a/unpacked/jax/output/CommonHTML/autoload/mglyph.js
+++ b/unpacked/jax/output/CommonHTML/autoload/mglyph.js
@@ -60,15 +60,15 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
           var img = CHTML.addElement(node,"img",{
             isMathJax:true, src:values.src, alt:values.alt, title:values.alt
           });
-          var w = bbox.img.img.width/CHTML.em, h = bbox.img.img.height/CHTML.em;
-          if (values.width !== "")  img.style.width  = CHTML.Em(this.CHTMLlength2em(values.width,w));
-          if (values.height !== "") img.style.height = CHTML.Em(this.CHTMLlength2em(values.height,h));
-          //
-          //  Warning:  causes page reflows
-          //
-          bbox.w = bbox.r = img.offsetWidth/CHTML.em; bbox.h = bbox.t = img.offsetHeight/CHTML.em;
+          var w = values.width, h = values.height;
+          var W = bbox.img.img.width/CHTML.em, H = bbox.img.img.height/CHTML.em;
+          var WW = W, HH = H;
+          if (w !== "") {W = this.CHTMLlength2em(w,WW); H = (WW ? W/WW * HH : 0)}
+          if (h !== "") {H = this.CHTMLlength2em(h,HH); if (w === "") W = (HH ? H/HH * WW : 0)}
+          img.style.width  = CHTML.Em(W); bbox.w = bbox.r = W;
+          img.style.height = CHTML.Em(H); bbox.h = bbox.t = H;
           if (values.valign) {
-            bbox.d = bbox.b = -this.CHTMLlength2em(values.valign,h);
+            bbox.d = bbox.b = -this.CHTMLlength2em(values.valign,HH);
             img.style.verticalAlign = CHTML.Em(-bbox.d);
             bbox.h -= bbox.d; bbox.t = bbox.h;
           }


### PR DESCRIPTION
Make CHTML `mglyph` scale image size by hand rather than using `offsetWidth` and `offsetHeight`, since those cause reflow. This also makes it work in mathjax-node.  Resolves mathjax/Mathjax-node#241.