### PR TITLE
Don't copy environment into array environments.  #1468

### DIFF
--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -53,8 +53,10 @@
         else if (top) {
           this.data.push(item);
           if (item.env) {
-            for (var id in this.env)
-              {if (this.env.hasOwnProperty(id)) {item.env[id] = this.env[id]}}
+            if (item.copyEnv !== false) {
+              for (var id in this.env)
+                {if (this.env.hasOwnProperty(id)) {item.env[id] = this.env[id]}}
+            }
             this.env = item.env;
           } else {item.env = this.env}
         }
@@ -258,7 +260,8 @@
   STACKITEM.array = STACKITEM.Subclass({
     type: "array", isOpen: true, arraydef: {},
     Init: function () {
-      this.table = []; this.row = []; this.env = {}; this.frame = []; this.hfill = [];
+      this.table = []; this.row = []; this.frame = []; this.hfill = [];
+      this.copyEnv = false;
       this.SUPER(arguments).Init.apply(this,arguments);
     },
     checkItem: function (item) {

--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -258,10 +258,9 @@
   });
   
   STACKITEM.array = STACKITEM.Subclass({
-    type: "array", isOpen: true, arraydef: {},
+    type: "array", isOpen: true, copyEnv: false, arraydef: {},
     Init: function () {
       this.table = []; this.row = []; this.frame = []; this.hfill = [];
-      this.copyEnv = false;
       this.SUPER(arguments).Init.apply(this,arguments);
     },
     checkItem: function (item) {


### PR DESCRIPTION
Don't copy environment into array environments.  Use

```
\mathbf{\begin{array}{cc}x&y\end{array}}
```

to test it (the `x` should not be in bold).  Resolves issue #1468.