### PR TITLE
Allow MathJax root to be configured.  #1403

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -2503,6 +2503,11 @@ MathJax.Hub.Startup = {
   Config: function () {
     this.queue.Push(["Post",this.signal,"Begin Config"]);
     //
+    //  Make sure root is set before loading any files
+    //
+    if (MathJax.AuthorConfig && MathJax.AuthorConfig.root)
+      MathJax.Ajax.config.root = MathJax.AuthorConfig.root;
+    //
     //  If a locale is given as a parameter,
     //    set the locale and the default menu value for the locale
     //
@@ -2552,15 +2557,15 @@ MathJax.Hub.Startup = {
   //
   ConfigBlocks: function () {
     var scripts = document.getElementsByTagName("script");
-    var last = null, queue = MathJax.Callback.Queue();
+    var queue = MathJax.Callback.Queue();
     for (var i = 0, m = scripts.length; i < m; i++) {
       var type = String(scripts[i].type).replace(/ /g,"");
       if (type.match(/^text\/x-mathjax-config(;.*)?$/) && !type.match(/;executed=true/)) {
         scripts[i].type += ";executed=true";
-        last = queue.Push(scripts[i].innerHTML+";\n1;");
+        queue.Push(scripts[i].innerHTML+";\n1;");
       }
     }
-    return last;
+    return queue.Push(function () {MathJax.Ajax.config.root = MathJax.Hub.config.root});
   },
 
   //


### PR DESCRIPTION
Allow MathJax root to be configured.  Resolves issue #1403.

The best way to set the root is to use

```
<script>
MathJax = {root:"http://myhost.net/mathjax"};
</script>
<script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
```

so that the configuration file will be loaded from the correct location as well. Otherwise, you can use

```
<script type="text/x-mathjax-config">
MathJax.Hub.Config({
  root:"http://myhost.net/mathjax",
  config: ["TeX-AMS_HTML.js"]
});
</script>
<script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
```
