### PR TITLE
Fix spelling of 'protocol'.  Issue #1519.

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -659,7 +659,7 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
   
   var PATH = {};
   PATH[BASENAME] = "";  // empty path gets the root URL
-  PATH.Contrib = (String(location.protocal).match(/^https?:/) ? "" : "http:") +
+  PATH.Contrib = (String(location.protocol).match(/^https?:/) ? "" : "http:") +
                    "//cdn.mathjax.org/mathjax/contrib";   // the third-party extensions
   
   BASE.Ajax = {


### PR DESCRIPTION
Fix spelling error reported by Peter.  #1519