### PR TITLE
Make sure CHTML output stays a table-cell when focused.

### DIFF
--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -72,7 +72,7 @@
       display: "inline-table"  // see issues #1282 and #1338
     },
     ".mjx-full-width": {
-      display: "table-cell",
+      display: "table-cell!important",
       width:   "10000em"
     },
 


### PR DESCRIPTION
This fixes a problem in Firefox with CHTML output that includes labeled rows.  When they gain focus, they could change size (due to the changes in commit 97ab12e).  This prevents that from happening. Other browsers don't seem to have this problem.