### PR TITLE
Make mhchem have a config parameter to select the new version

### DIFF
--- a/unpacked/extensions/TeX/mhchem.js
+++ b/unpacked/extensions/TeX/mhchem.js
@@ -26,8 +26,18 @@
  */
 
 MathJax.Extension["TeX/mhchem"] = {
-  version: "2.6.0"
+  version: "2.6.0",
+  config: MathJax.Hub.CombineConfig("TeX.mhchem",{
+    legacy: true
+  })
 };
+
+if (!MathJax.Extension["TeX/mhchem"].config.legacy) {
+  MathJax.Callback.Queue(
+    ["Require",MathJax.Ajax,"[Contrib]/mhchem/mhchem.js"],
+    ["loadComplete",MathJax.Ajax,"[MathJax]/extensions/TeX/mhchem.js"]
+  );
+} else {
 
 MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
   
@@ -492,3 +502,4 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
 });
 
 MathJax.Ajax.loadComplete("[MathJax]/extensions/TeX/mhchem.js");
+}


### PR DESCRIPTION
Make mhchem have a config parameter that can be used to select the new version (when it is available on the CDN) or the old legacy version.  The default is the legacy version, so this is an opt-in for the new mhchem, which is what I think we agreed on.  The parameter is named `legacy`, but I am open to other suggestions.

I had to put the old version inside an `if-then` statement, but I didn't re-indent it, as I didn't want the difference to look extensive than it is.  Volker may want me to change that.  :-)