### PR TITLE
Fix fractions with line breaks in HTML output.  #1539

### DIFF
--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -2413,6 +2413,7 @@
       toCommonHTML: function (node) {
         node = this.CHTMLdefaultNode(node,{
           childNodes:["mjx-numerator","mjx-denominator"],
+          childOptions: {autowidth: true},
           forceChild:true, noBBox:true, minChildren:2
         });
         var values = this.getValues("linethickness","displaystyle",
@@ -2600,7 +2601,7 @@
     /********************************************************/
     
     MML.mrow.Augment({
-      toCommonHTML: function (node) {
+      toCommonHTML: function (node,options) {
         node = this.CHTMLdefaultNode(node);
         var bbox = this.CHTML, H = bbox.h, D = bbox.d, hasNegative;
         for (var i = 0, m = this.data.length; i < m; i++) {
@@ -2609,6 +2610,7 @@
         }
         if (this.CHTMLlineBreaks()) {
           this.CHTMLmultiline(node);
+          if (options.autowidth) node.style.width = "";
         } else {
           if (hasNegative && bbox.w) node.style.width = CHTML.Em(Math.max(0,bbox.w));
           if (bbox.w < 0) node.style.marginRight = CHTML.Em(bbox.w);

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -2602,6 +2602,7 @@
     
     MML.mrow.Augment({
       toCommonHTML: function (node,options) {
+        options = options || {};
         node = this.CHTMLdefaultNode(node);
         var bbox = this.CHTML, H = bbox.h, D = bbox.d, hasNegative;
         for (var i = 0, m = this.data.length; i < m; i++) {
@@ -2610,7 +2611,7 @@
         }
         if (this.CHTMLlineBreaks()) {
           this.CHTMLmultiline(node);
-          if ((options||{}).autowidth) node.style.width = "";
+          if (options.autowidth) node.style.width = "";
         } else {
           if (hasNegative && bbox.w) node.style.width = CHTML.Em(Math.max(0,bbox.w));
           if (bbox.w < 0) node.style.marginRight = CHTML.Em(bbox.w);

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -2610,7 +2610,7 @@
         }
         if (this.CHTMLlineBreaks()) {
           this.CHTMLmultiline(node);
-          if (options.autowidth) node.style.width = "";
+          if ((options||{}).autowidth) node.style.width = "";
         } else {
           if (hasNegative && bbox.w) node.style.width = CHTML.Em(Math.max(0,bbox.w));
           if (bbox.w < 0) node.style.marginRight = CHTML.Em(bbox.w);

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -1291,7 +1291,7 @@
         if (bbox.tw) {BBOX.tw = bbox.tw}
       }
     },
-    alignBox: function (span,align,y,dx) {
+    alignBox: function (span,align,y,dx,noskip) {
       if (dx == null) {dx = 0}
       this.placeBox(span,dx,y); // set y position (and left aligned)
       if (this.msiePlaceBoxBug) {
@@ -1302,7 +1302,7 @@
         while (node && node.nodeName !== "#text") {node = node.previousSibling}
         if (node) {span.removeChild(node)}
       }
-      var bbox = span.bbox; if (bbox.isMultiline) return;
+      var bbox = span.bbox; if (bbox.isMultiline && !noskip) return;
       var isRelative = bbox.width != null && !bbox.isFixed;
       var r = 0, c = dx-bbox.w/2, l = "50%";
       if (this.initialSkipBug) {r = bbox.w-bbox.rw-.1; c += bbox.lw}
@@ -2581,8 +2581,8 @@
 	    HTMLCSS.createRule(rule,t,0,W+2*t);
 	    HTMLCSS.placeBox(rule,0,a-t/2);
 	  }
-	  HTMLCSS.alignBox(num,values.numalign,u);
-	  HTMLCSS.alignBox(den,values.denomalign,-v);
+	  HTMLCSS.alignBox(num,values.numalign,u,0,true);
+	  HTMLCSS.alignBox(den,values.denomalign,-v,0,true);
 	}
 	this.HTMLhandleSpace(span);
 	this.HTMLhandleColor(span);


### PR DESCRIPTION
Make fractions with linebreaks center the elements based on the natural width (not 100%) in HTML-CSS and CHTML, just as in SVG.  Resolves issue #1539.