### PR TITLE
Fix determination of line-breaing parent element. #1548.

### DIFF
--- a/unpacked/jax/output/CommonHTML/autoload/multiline.js
+++ b/unpacked/jax/output/CommonHTML/autoload/multiline.js
@@ -68,7 +68,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       //
       var parent = this;
       while (parent.inferred || (parent.parent && parent.parent.type === "mrow" &&
-             parent.parent.data.length === 1)) {parent = parent.parent}
+             parent.parent.isEmbellished())) {parent = parent.parent}
       var isTop = ((parent.type === "math" && parent.Get("display") === "block") ||
                     parent.type === "mtd");
       parent.isMultiline = true;
@@ -234,6 +234,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       else                   align = prev.indentalign || def.indentalign;
       if (align === MML.INDENTALIGN.INDENTALIGN) align = prev.indentalign || def.indentalign;
       if (align === MML.INDENTALIGN.AUTO) align = (state.isTop ? CONFIG.displayAlign : MML.INDENTALIGN.LEFT);
+console.log(align,state.isTop);
       return align;
     },
     CHTMLgetShift: function (state,values,align,noadjust) {

--- a/unpacked/jax/output/CommonHTML/autoload/multiline.js
+++ b/unpacked/jax/output/CommonHTML/autoload/multiline.js
@@ -234,7 +234,6 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       else                   align = prev.indentalign || def.indentalign;
       if (align === MML.INDENTALIGN.INDENTALIGN) align = prev.indentalign || def.indentalign;
       if (align === MML.INDENTALIGN.AUTO) align = (state.isTop ? CONFIG.displayAlign : MML.INDENTALIGN.LEFT);
-console.log(align,state.isTop);
       return align;
     },
     CHTMLgetShift: function (state,values,align,noadjust) {

--- a/unpacked/jax/output/HTML-CSS/autoload/multiline.js
+++ b/unpacked/jax/output/HTML-CSS/autoload/multiline.js
@@ -67,7 +67,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
       //
       var parent = this;
       while (parent.inferred || (parent.parent && parent.parent.type === "mrow" &&
-             parent.parent.data.length === 1)) {parent = parent.parent}
+             parent.isEmbellished())) {parent = parent.parent}
       var isTop = ((parent.type === "math" && parent.Get("display") === "block") ||
                     parent.type === "mtd");
       parent.isMultiline = true;

--- a/unpacked/jax/output/SVG/autoload/multiline.js
+++ b/unpacked/jax/output/SVG/autoload/multiline.js
@@ -65,7 +65,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       //
       var parent = this;
       while (parent.inferred || (parent.parent && parent.parent.type === "mrow" &&
-             parent.parent.data.length === 1)) {parent = parent.parent}
+             parent.isEmbellished())) {parent = parent.parent}
       var isTop = ((parent.type === "math" && parent.Get("display") === "block") ||
                     parent.type === "mtd");
       parent.isMultiline = true;


### PR DESCRIPTION
Fix determination of line-breaking parent element.  It was moving too high in some cases.  E.g., in

```
  <mrow>
    <msqrt>
      ...
    </msqrt>
  </mrow>
```

the inferred mrow in the msqrt was stepping out to the msqrt (correctly) but then stepped out to the mrow and its parent (since it was an mrow with one child).  The change to `parent.isEmbellished()` causes the stepping out to occur only when the outer mrow represents an embellished operator.  (We only want `isTop` to be true in that case.)

Resolves issue #1548.