### PR TITLE
Fix vector arrow positioning in CHTML.  #1543

### DIFF
--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -1882,7 +1882,7 @@
         //  something, so put them over a space and remove the space's width
         //
         node = node.firstChild;
-        var space = CHTML.Element("mjx-span",{style:{width:".25em","margin-left":"-.25em"}});
+        var space = CHTML.Element("mjx-box",{style:{width:".25em","margin-left":"-.25em"}});
         node.insertBefore(space,node.firstChild);
       },
       CHTMLcenterOp: function (node) {


### PR DESCRIPTION
Change class to mjx-box so that width will have the proper effect (due to fix in CSS in PR #1448).  Resolves issue #1543.