### PR TITLE
Allow <wbr> in TeX code (just like <br>).  #1087

### DIFF
--- a/unpacked/extensions/asciimath2jax.js
+++ b/unpacked/extensions/asciimath2jax.js
@@ -48,10 +48,19 @@ MathJax.Extension.asciimath2jax = {
                                            // are ignored.  Note that this is a regular expression,
                                            // so be sure to quote any regexp special characters
 
-    preview: "AsciiMath"        // set to "none" to not insert MathJax_Preview spans
+    preview: "AsciiMath"       // set to "none" to not insert MathJax_Preview spans
                                //   or set to an array specifying an HTML snippet
                                //   to use the same preview for every equation.
 
+  },
+  
+  //
+  //  Tags to ignore when searching for AsciiMath in the page
+  //
+  ignoreTags: {
+    br: (MathJax.Hub.Browser.isMSIE && document.documentMode < 9 ? "\n" : " "),
+    wbr: "",
+    "#comment": ""
   },
   
   PreProcess: function (element) {
@@ -132,8 +141,7 @@ MathJax.Extension.asciimath2jax = {
       if (this.search.matched) {element = this.encloseMath(element)}
       if (element) {
         do {prev = element; element = element.nextSibling}
-          while (element && (element.nodeName.toLowerCase() === 'br' ||
-                             element.nodeName.toLowerCase() === '#comment'));
+          while (element && this.ignoreTags[element.nodeName.toLowerCase()] != null);
         if (!element || element.nodeName !== '#text') {return prev}
       }
     }
@@ -172,25 +180,24 @@ MathJax.Extension.asciimath2jax = {
   },
   
   encloseMath: function (element) {
-    var search = this.search, close = search.close, CLOSE, math;
+    var search = this.search, close = search.close, CLOSE, math, next;
     if (search.cpos === close.length) {close = close.nextSibling}
        else {close = close.splitText(search.cpos)}
     if (!close) {CLOSE = close = MathJax.HTML.addText(search.close.parentNode,"")}
     search.close = close;
     math = (search.opos ? search.open.splitText(search.opos) : search.open);
-    while (math.nextSibling && math.nextSibling !== close) {
-      if (math.nextSibling.nodeValue !== null) {
-        if (math.nextSibling.nodeName === "#comment") {
-          math.nodeValue += math.nextSibling.nodeValue.replace(/^\[CDATA\[((.|\n|\r)*)\]\]$/,"$1");
+    while ((next = math.nextSibling) && next !== close) {
+      if (next.nodeValue !== null) {
+        if (next.nodeName === "#comment") {
+          math.nodeValue += next.nodeValue.replace(/^\[CDATA\[((.|\n|\r)*)\]\]$/,"$1");
         } else {
           math.nodeValue += math.nextSibling.nodeValue;
         }
-      } else if (this.msieNewlineBug) {
-        math.nodeValue += (math.nextSibling.nodeName.toLowerCase() === "br" ? "\n" : " ");
       } else {
-        math.nodeValue += " ";
+        var ignore = this.ignoreTags[next.nodeName.toLowerCase()];
+        math.nodeValue += (ignore == null ? " " : ignore);
       }
-      math.parentNode.removeChild(math.nextSibling);
+      math.parentNode.removeChild(next);
     }
     var AM = math.nodeValue.substr(search.olen,math.nodeValue.length-search.olen-search.clen);
     math.parentNode.removeChild(math);
@@ -224,9 +231,7 @@ MathJax.Extension.asciimath2jax = {
     return script;
   },
   
-  filterPreview: function (asciimath) {return asciimath},
-  
-  msieNewlineBug: (MathJax.Hub.Browser.isMSIE && (document.documentMode||0) < 9)
+  filterPreview: function (asciimath) {return asciimath}
   
 };
 

--- a/unpacked/extensions/tex2jax.js
+++ b/unpacked/extensions/tex2jax.js
@@ -263,7 +263,7 @@ MathJax.Extension.tex2jax = {
         } else {
           math.nodeValue += next.nodeValue;
         }
-      } else{
+      } else {
         var ignore = this.ignoreTags[next.nodeName.toLowerCase()];
         math.nodeValue += (ignore == null ? " " : ignore);
       }


### PR DESCRIPTION
Add `<wbr>` as an ignored tag, and change to a list of ones to ignore.  Cache the `math.nextSibling` node.  Remove `msieNewlineBug` and fold that into the `ignoreTags` hash.  Resolves issue #1087.