### PR TITLE
Handle hrefs during line breaking.  #1022

### DIFF
--- a/unpacked/jax/output/CommonHTML/autoload/multiline.js
+++ b/unpacked/jax/output/CommonHTML/autoload/multiline.js
@@ -312,6 +312,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       if (this.CHTML.R && margin !== "marginRight") state.bbox.w += this.CHTML.R;
       if (end.length === 0) {
         node = this.CHTMLnodeElement();
+        if (this.href) node = node.parentNode;
         node.parentNode.removeChild(node);
         node.nextMathJaxNode.id = node.id;
       }
@@ -326,6 +327,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
     //
     CHTMLcreateSliceNode: function (node) {
       var NODE = this.CHTMLnodeElement(), n = 0;
+      if (this.href) NODE = NODE.parentNode;
       var LAST = NODE; while (LAST.nextMathJaxNode) {LAST = LAST.nextMathJaxNode; n++}
       var SLICE = NODE.cloneNode(false); LAST.nextMathJaxNode = SLICE; SLICE.nextMathJaxNode = null;
       SLICE.id += "-MJX-Continue-"+n;
@@ -347,6 +349,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
         //  Move node
         //
         var node = this.CHTMLnodeElement();
+        if (this.href) node = node.parentNode;
         line.appendChild(node);
         if (this.CHTML.pwidth && !line.style.width) line.style.width = this.CHTML.pwidth;
         //
@@ -565,7 +568,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
     },
     
     CHTMLmoveLine: function (start,end,node,state,values) {
-      var NODE = this.CHTMLnodeElement(), BOX = this.CHTMLbbox, w;
+      var NODE, BOX = this.CHTMLbbox, w;
       //
       //  If this is the start, move the prescripts, if any.
       //

--- a/unpacked/jax/output/HTML-CSS/autoload/multiline.js
+++ b/unpacked/jax/output/HTML-CSS/autoload/multiline.js
@@ -315,10 +315,13 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
       this.HTMLcleanBBox(slice.bbox);
       if (end.length === 0) {
         span = this.HTMLspanElement();
+        if (this.href) span = span.parentNode;
         span.parentNode.removeChild(span);
         span.nextMathJaxSpan.id = span.id; var n = 0;
         while (span = span.nextMathJaxSpan) {
-          var color = this.HTMLhandleColor(span);
+          var SPAN = span;
+          if (SPAN.nodeName.toLowerCase() === "a") SPAN = SPAN.firstChild;
+          var color = this.HTMLhandleColor(SPAN);
           if (color) {color.id += "-MathJax-Continue-"+n; n++}
         }
       }
@@ -333,6 +336,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
     //
     HTMLcreateSliceSpan: function (span) {
       var SPAN = this.HTMLspanElement(), n = 0;
+      if (this.href) SPAN = SPAN.parentNode;
       var LAST = SPAN; while (LAST.nextMathJaxSpan) {LAST = LAST.nextMathJaxSpan; n++}
       var SLICE = SPAN.cloneNode(false); LAST.nextMathJaxSpan = SLICE; SLICE.nextMathJaxSpan = null;
       SLICE.id += "-MathJax-Continue-"+n;
@@ -357,6 +361,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
 	var color = document.getElementById("MathJax-Color-"+this.spanID+HTMLCSS.idPostfix);
         if (color) {line.appendChild(color)}
         var span = this.HTMLspanElement();
+        if (this.href) span = span.parentNode;
         line.appendChild(span);
         //
         //  If it is last, remove right padding
@@ -515,7 +520,9 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
       if (end.length === 0) {
         var s = this.data[this.sup] || this.data[this.sub];
         if (s && this.HTMLnotEmpty(s)) {
-          var box = s.HTMLspanElement().parentNode, stack = box.parentNode;
+          var box = s.HTMLspanElement().parentNode;
+          if (s.href) box = box.parentNode;
+          var stack = box.parentNode;
           if (this.data[this.base]) {stack.removeChild(stack.firstChild)}
 	  for (box = stack.firstChild; box; box = box.nextSibling)
 	    {box.style.left = HTMLCSS.Em(HTMLCSS.unEm(box.style.left)-this.HTMLbaseW)}

--- a/unpacked/jax/output/SVG/autoload/multiline.js
+++ b/unpacked/jax/output/SVG/autoload/multiline.js
@@ -308,6 +308,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       var slice = BBOX();
       this.SVGmoveLine(start,end,slice,state,values);
       slice.Clean();
+      if (this.href) {this.SVGaddHref(slice)}
       this.SVGhandleColor(slice);
       svg.Add(slice,svg.w,0,true);
       return slice;

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -1127,22 +1127,7 @@
         // FIXME:  if an element is split by linebreaking, the ID will be the same on both parts
         // FIXME:  if an element has an id, its zoomed copy will have the same ID
         if (this.id) {svg.removeable = false; SVG.Element(svg.element,{"id":this.id})}
-        if (this.href) {
-	  var a = SVG.Element("a",{"class":"mjx-svg-href"});
-	  a.setAttributeNS(XLINKNS,"href",this.href);
-          a.onclick = this.SVGlink;
-          SVG.addElement(a,"rect",{width:svg.w, height:svg.h+svg.d, y:-svg.d,
-                                   fill:"none", stroke:"none", "pointer-events":"all"});
-          if (svg.type === "svg") {
-            // for svg element, put <a> inside the main <g> element
-            var g = svg.element.firstChild;
-            while (g.firstChild) {a.appendChild(g.firstChild)}
-            g.appendChild(a);
-          } else {
-            a.appendChild(svg.element); svg.element = a;
-          }
-          svg.removeable = false;
-        }
+        if (this.href) {this.SVGaddHref(svg)}
         if (SVG.config.addMMLclasses) {
           this.SVGaddClass(svg.element,"mjx-svg-"+this.type);
           svg.removeable = false;
@@ -1181,6 +1166,22 @@
             }
           }
         }
+      },
+      SVGaddHref: function (svg) {
+	var a = SVG.Element("a",{"class":"mjx-svg-href"});
+        a.setAttributeNS(XLINKNS,"href",this.href);
+        a.onclick = this.SVGlink;
+        SVG.addElement(a,"rect",{width:svg.w, height:svg.h+svg.d, y:-svg.d,
+                                 fill:"none", stroke:"none", "pointer-events":"all"});
+        if (svg.type === "svg") {
+          // for svg element, put <a> inside the main <g> element
+          var g = svg.element.firstChild;
+          while (g.firstChild) {a.appendChild(g.firstChild)}
+          g.appendChild(a);
+        } else {
+          a.appendChild(svg.element); svg.element = a;
+        }
+        svg.removeable = false;
       },
       //
       //  WebKit currently scrolls to the BOTTOM of an svg element if it contains the


### PR DESCRIPTION
Fix line breaking to handle hrefs properly both when they are split and when they are not.  This affects HTML-CSS, CHTML, and SVG output.  Resolves issue #1022.