### PR TITLE
Improve menu placement.  #1434

### DIFF
--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -313,6 +313,9 @@
       this.posted = true;
       if (menu.offsetWidth) menu.style.width = (menu.offsetWidth+2) + "px";
       var x = event.pageX, y = event.pageY;
+      var bbox = document.body.getBoundingClientRect();
+      var styles = window.getComputedStyle(document.body);
+      var bodyRight = bbox.right - Math.min(0,bbox.left) + parseFloat(styles.marginLeft);
       if (!x && !y && "clientX" in event) {
         x = event.clientX + document.body.scrollLeft + document.documentElement.scrollLeft;
         y = event.clientY + document.body.scrollTop  + document.documentElement.scrollTop;
@@ -326,8 +329,8 @@
           x = (rect.right + rect.left) / 2 + offsetX;
           y = (rect.bottom + rect.top) / 2 + offsetY;
         }
-        if (x + menu.offsetWidth > document.body.offsetWidth - this.margin)
-           {x = document.body.offsetWidth - menu.offsetWidth - this.margin}
+        if (x + menu.offsetWidth > bodyRight - this.margin)
+          {x = bodyRight - menu.offsetWidth - this.margin}
         if (MENU.isMobile) {x = Math.max(5,x-Math.floor(menu.offsetWidth/2)); y -= 20}
         MENU.skipUp = event.isContextMenu;
       } else {
@@ -339,7 +342,7 @@
         }
         if (!MENU.isMobile) {
           if ((MENU.isRTL && x - mw - menu.offsetWidth > this.margin) ||
-              (!MENU.isRTL && x + menu.offsetWidth > document.body.offsetWidth - this.margin))
+              (!MENU.isRTL && x + menu.offsetWidth > bodyRight - this.margin))
             {side = "right"; x = Math.max(this.margin,x - mw - menu.offsetWidth + 6)}
         }
         if (!isPC) {

--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -314,7 +314,7 @@
       if (menu.offsetWidth) menu.style.width = (menu.offsetWidth+2) + "px";
       var x = event.pageX, y = event.pageY;
       var bbox = document.body.getBoundingClientRect();
-      var styles = window.getComputedStyle(document.body);
+      var styles = (window.getComputedStyle ? window.getComputedStyle(document.body) : {marginLeft: "0px"});
       var bodyRight = bbox.right - Math.min(0,bbox.left) + parseFloat(styles.marginLeft);
       if (!x && !y && "clientX" in event) {
         x = event.clientX + document.body.scrollLeft + document.documentElement.scrollLeft;


### PR DESCRIPTION
Use `getBoundingClientRect()` to improve handling of menu placement when the body is scrolled or has margin settings.  Resolves issue #1434.

Here `bbox.right` gives the position of the right-hand side of the body, unless it is scrolled left, in which case the `bbox.left` will be negative, so we add it in.  These don't seem to take the left margin into account, so we add that in as well.