### PR TITLE
Fix spacing for initial fraction in exponent position.  #911

### DIFF
--- a/unpacked/jax/element/mml/jax.js
+++ b/unpacked/jax/element/mml/jax.js
@@ -376,7 +376,7 @@ MathJax.ElementJax.mml.Augment({
       if (prev === MML.TEXCLASS.VCENTER) {prev = MML.TEXCLASS.ORD}
       if (tex  === MML.TEXCLASS.VCENTER) {tex  = MML.TEXCLASS.ORD}
       var space = this.TEXSPACE[prev][tex];
-      if (this.prevLevel > 0 && this.Get("scriptlevel") > 0 && space >= 0) {return ""}
+      if ((this.prevLevel > 0 || this.Get("scriptlevel") > 0) && space >= 0) {return ""}
       return this.TEXSPACELENGTH[Math.abs(space)];
     },
     TEXSPACELENGTH:[


### PR DESCRIPTION
Don't require both `prevLevel > 0` and `scriptlevel > 0` (either true should be sufficient) when determining TeX spacing.  This gets the spacing right for `e^{\tfrac{1}{2} + c}`.

Resolves issue #911.