### PR TITLE
Use currentColor rather than black for menclose with no math color.  #1573

### DIFF
--- a/unpacked/jax/output/HTML-CSS/autoload/menclose.js
+++ b/unpacked/jax/output/HTML-CSS/autoload/menclose.js
@@ -55,7 +55,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
       HTMLCSS.addBox(stack,frame); stack.insertBefore(frame,base); // move base to above background
       var T = 0, B = 0, R = 0, L = 0, dx = 0, dy = 0; var svg, vml;
       var w, h, r;
-      if (!values.mathcolor) {values.mathcolor = "black"} else {span.style.color = values.mathcolor}
+      if (!values.mathcolor) {values.mathcolor = "currentColor"} else {span.style.color = values.mathcolor}
 
       // perform some reduction e.g. eliminate duplicate notations.
       var nl = MathJax.Hub.SplitList(values.notation), notation = {};

--- a/unpacked/jax/output/SVG/autoload/menclose.js
+++ b/unpacked/jax/output/SVG/autoload/menclose.js
@@ -113,7 +113,6 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       t = Math.max(1/SVG.em,t);  // see issue #414
       var H = base.h+p+t, D = base.d+p+t, W = base.w+2*(p+t);
       var dx = 0, w, h, i, m, borders = [false,false,false,false];
-      if (!values.mathcolor) {values.mathcolor = "currenColor"}
 
       // perform some reduction e.g. eliminate duplicate notations.
       var nl = MathJax.Hub.SplitList(values.notation), notation = {};

--- a/unpacked/jax/output/SVG/autoload/menclose.js
+++ b/unpacked/jax/output/SVG/autoload/menclose.js
@@ -113,7 +113,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       t = Math.max(1/SVG.em,t);  // see issue #414
       var H = base.h+p+t, D = base.d+p+t, W = base.w+2*(p+t);
       var dx = 0, w, h, i, m, borders = [false,false,false,false];
-      if (!values.mathcolor) {values.mathcolor = "black"}
+      if (!values.mathcolor) {values.mathcolor = "currenColor"}
 
       // perform some reduction e.g. eliminate duplicate notations.
       var nl = MathJax.Hub.SplitList(values.notation), notation = {};


### PR DESCRIPTION
Use currentColor rather than black for menclose when mathcolor isn't specified.

Resolves issue #1573.