### PR TITLE
avoid 'x instanceof Array' (closes #1584)

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -291,11 +291,11 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
             {args = [].slice.call(args,i)}
       else {args = [].slice.call(arguments,0)}
     }
-    if (args instanceof Array && args.length === 1) {args = args[0]}
+    if (Object.prototype.toString.call(args) === "[object Array]" && args.length === 1) {args = args[0]}
     if (typeof args === 'function') {
       if (args.execute === CALLBACK.prototype.execute) {return args}
       return CALLBACK({hook: args});
-    } else if (args instanceof Array) {
+    } else if (Object.prototype.toString.call(args) === "[object Array]") {
       if (typeof(args[0]) === 'string' && args[1] instanceof Object &&
                  typeof args[1][args[0]] === 'function') {
         return CALLBACK({hook: args[1][args[0]], object: args[1], data: args.slice(2)});
@@ -343,7 +343,7 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
     }
   };
   var WAITSIGNAL = function (callback,signals) {
-    if (!(signals instanceof Array)) {signals = [signals]}
+    if (!(Object.prototype.toString.call(signals) === "[object Array]")) {signals = [signals]}
     if (!callback.signal) {
       callback.oldExecute = callback.execute;
       callback.execute = WAITEXECUTE;
@@ -442,8 +442,8 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
   //
   var EXECUTEHOOKS = function (hooks,data,reset) {
     if (!hooks) {return null}
-    if (!(hooks instanceof Array)) {hooks = [hooks]}
-    if (!(data instanceof Array))  {data = (data == null ? [] : [data])}
+    if (!(Object.prototype.toString.call(hooks) === "[object Array]")) {hooks = [hooks]}
+    if (!(Object.prototype.toString.call(data) === "[object Array]"))  {data = (data == null ? [] : [data])}
     var handler = HOOKS(reset);
     for (var i = 0, m = hooks.length; i < m; i++) {handler.Add(hooks[i])}
     return handler.Execute.apply(handler,data);
@@ -592,7 +592,7 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
     //  Execute the message hooks for the given message
     //
     ExecuteHooks: function (msg) {
-      var type = ((msg instanceof Array) ? msg[0] : msg);
+      var type = ((Object.prototype.toString.call(msg) === "[object Array]") ? msg[0] : msg);
       if (!this.hooks[type]) {return null}
       return this.hooks[type].Execute(msg);
     },
@@ -1055,7 +1055,7 @@ MathJax.HTML = {
       }
     }
     if (contents) {
-      if (!(contents instanceof Array)) {contents = [contents]}
+      if (!(Object.prototype.toString.call(contents) === "[object Array]")) {contents = [contents]}
       for (var i = 0, m = contents.length; i < m; i++) {
         if (contents[i] instanceof Array) {
           obj.appendChild(this.Element(contents[i][0],contents[i][1],contents[i][2]));
@@ -1220,7 +1220,7 @@ MathJax.Localization = {
     }),
   
   _: function (id,phrase) {
-    if (phrase instanceof Array) {return this.processSnippet(id,phrase)}
+    if (Object.prototype.toString.call(phrase) === "[object Array]") {return this.processSnippet(id,phrase)}
     return this.processString(this.lookupPhrase(id,phrase),[].slice.call(arguments,2));
   },
   
@@ -1310,7 +1310,7 @@ MathJax.Localization = {
         //    [id,string,args] or [domain,snippet]
         var data = snippet[i];
         if (typeof data[1] === "string") {        // [id,string,args]
-          var id = data[0]; if (!(id instanceof Array)) {id = [domain,id]}
+          var id = data[0]; if (!(Object.prototype.toString.call(id) === "[object Array]")) {id = [domain,id]}
           var phrase = this.lookupPhrase(id,data[1]);
           result = result.concat(this.processMarkdown(phrase,data.slice(2),domain));
         } else if (data[1] instanceof Array) {    // [domain,snippet]
@@ -1349,7 +1349,7 @@ MathJax.Localization = {
         //  Select the tag to use by number of stars (three stars requires two tags)
         //
         data = this.processString(parts[i+2],args,domain);
-        if (!(data instanceof Array)) {data = [data]}
+        if (!(Object.prototype.toString.call(data) === "[object Array]")) {data = [data]}
         data = [["b","i","i"][parts[i+1].length-1],{},data]; // number of stars determines type
         if (parts[i+1].length === 3) {data = ["b",{},data]}  // bold-italic
       } else if (parts[i+3]) { //  backtics (for code)
@@ -1358,14 +1358,14 @@ MathJax.Localization = {
         //  Make a <code> tag
         //
         data = this.processString(parts[i+4].replace(/^\s/,"").replace(/\s$/,""),args,domain);
-        if (!(data instanceof Array)) {data = [data]}
+        if (!(Object.prototype.toString.call(data) === "[object Array]")) {data = [data]}
         data = ["code",{},data];
       } else if (parts[i+5]) { //  hyperlink
         //
         //  Process the link text, and make an <a> tag with the URL
         //
         data = this.processString(parts[i+5],args,domain);
-        if (!(data instanceof Array)) {data = [data]}
+        if (!(Object.prototype.toString.call(data) === "[object Array]")) {data = [data]}
         data = ["a",{href:this.processString(parts[i+6],args),target:"_blank"},data];
       } else {
         //
@@ -1400,7 +1400,7 @@ MathJax.Localization = {
       //  Then concatenate the snippet to the current one
       //
       string = this.processString(string,args,domain);
-      if (!(string instanceof Array)) {string = [string]}
+      if (!(Object.prototype.toString.call(string) === "[object Array]")) {string = [string]}
       result = result.concat(string);
     }
     return result;
@@ -1411,7 +1411,7 @@ MathJax.Localization = {
     //  Get the domain and messageID
     //
     if (!domain) {domain = "_"}
-    if (id instanceof Array) {domain = (id[0] || "_"); id = (id[1] || "")}
+    if (Object.prototype.toString.call(id) === "[object Array]") {domain = (id[0] || "_"); id = (id[1] || "")}
     //
     //  Check if the data is available and if not,
     //    load it and throw a restart error so the calling
@@ -1725,8 +1725,8 @@ MathJax.Message = {
     //  Translate message if it is [id,message,arguments]
     //
     var id = "";
-    if (text instanceof Array) {
-      id = text[0]; if (id instanceof Array) {id = id[1]}
+    if (Object.prototype.toString.call(text) === "[object Array]") {
+      id = text[0]; if (Object.prototype.toString.call(id) === "[object Array]") {id = id[1]}
       //
       // Localization._() will throw a restart error if a localization file
       //   needs to be loaded, so trap that and redo the Set() call
@@ -2404,11 +2404,11 @@ MathJax.Hub = {
   },
   
   elementCallback: function (element,callback) {
-    if (callback == null && (element instanceof Array || typeof element === 'function'))
+    if (callback == null && (Object.prototype.toString.call(element) === "[object Array]" || typeof element === 'function'))
       {try {MathJax.Callback(element); callback = element; element = null} catch(e) {}}
     if (element == null) {element = this.config.elements || []}
     if (this.isHTMLCollection(element)) {element = this.HTMLCollection2Array(element)}
-    if (!(element instanceof Array)) {element = [element]}
+    if (!(Object.prototype.toString.call(element) === "[object Array]")) {element = [element]}
     element = [].concat(element); // make a copy so the original isn't changed
     for (var i = 0, m = element.length; i < m; i++)
       {if (typeof(element[i]) === 'string') {element[i] = document.getElementById(element[i])}}
@@ -2424,7 +2424,7 @@ MathJax.Hub = {
   
   elementScripts: function (element) {
     var scripts = [];
-    if (element instanceof Array || this.isHTMLCollection(element)) {
+    if (Object.prototype.toString.call(element) === "[object Array]" || this.isHTMLCollection(element)) {
       for (var i = 0, m = element.length; i < m; i++) {
         var alreadyDone = 0;
         for (var j = 0; j < i && !alreadyDone; j++)
@@ -2778,7 +2778,7 @@ MathJax.Hub.Startup = {
   //
   loadArray: function (files,dir,name,synchronous) {
     if (files) {
-      if (!(files instanceof Array)) {files = [files]}
+      if (!(Object.prototype.toString.call(files) === "[object Array]")) {files = [files]}
       if (files.length) {
         var queue = MathJax.Callback.Queue(), callback = {}, file;
         for (var i = 0, m = files.length; i < m; i++) {
@@ -2888,11 +2888,11 @@ MathJax.Hub.Startup = {
     Process: function (script,state) {
       var queue = CALLBACK.Queue(), file;
       // Load any needed element jax
-      var jax = this.elementJax; if (!(jax instanceof Array)) {jax = [jax]}
+      var jax = this.elementJax; if (!(Object.prototype.toString.call(jax) === "[object Array]")) {jax = [jax]}
       for (var i = 0, m = jax.length; i < m; i++) {
         file = BASE.ElementJax.directory+"/"+jax[i]+"/"+this.JAXFILE;
         if (!this.require) {this.require = []}
-          else if (!(this.require instanceof Array)) {this.require = [this.require]};
+          else if (!(this.Object.prototype.toString.call(require) === "[object Array]")) {this.require = [this.require]};
         this.require.push(file);  // so Startup will wait for it to be loaded
         queue.Push(AJAX.Require(file));
       }
@@ -2947,7 +2947,7 @@ MathJax.Hub.Startup = {
         {jax[mimetype].unshift(this)} else {jax[mimetype].push(this)}
       //  Make sure the element jax is loaded before Startup is called
       if (!this.require) {this.require = []}
-        else if (!(this.require instanceof Array)) {this.require = [this.require]};
+        else if (!(this.Object.prototype.toString.call(require) === "[object Array]")) {this.require = [this.require]};
       this.require.push(BASE.ElementJax.directory+"/"+(mimetype.split(/\//)[1])+"/"+this.JAXFILE);
     },
     Remove: function (jax) {}

--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -806,7 +806,7 @@
     action: function () {},
 
     Init: function (name,action,def) {
-      if (!(name instanceof Array)) {name = [name,name]}  // make [id,label] pair
+      if (!(Object.prototype.toString.call(name) === "[object Array]")) {name = [name,name]}  // make [id,label] pair
       this.name = name; this.action = action;
       this.With(def);
     },
@@ -837,7 +837,7 @@
       return def;
     },
     Init: function (name,def) {
-      if (!(name instanceof Array)) {name = [name,name]}  // make [id,label] pair
+      if (!(Object.prototype.toString.call(name) === "[object Array]")) {name = [name,name]}  // make [id,label] pair
       this.name = name; var i = 1;
       if (!(def instanceof MENU.ITEM)) {this.With(def), i++}
       this.submenu = MENU.apply(MENU,[].slice.call(arguments,i));
@@ -936,7 +936,7 @@
       return def;
     },
     Init: function (name,variable,def) {
-      if (!(name instanceof Array)) {name = [name,name]}  // make [id,label] pair
+      if (!(Object.prototype.toString.call(name) === "[object Array]")) {name = [name,name]}  // make [id,label] pair
       this.name = name; this.variable = variable; this.With(def);
       if (this.value == null) {this.value = this.name[0]}
     },
@@ -983,7 +983,7 @@
       return def;
     },
     Init: function (name,variable,def) {
-      if (!(name instanceof Array)) {name = [name,name]}  // make [id,label] pair
+      if (!(Object.prototype.toString.call(name) === "[object Array]")) {name = [name,name]}  // make [id,label] pair
       this.name = name; this.variable = variable; this.With(def);
     },
     Label: function (def,menu) {
@@ -1012,7 +1012,7 @@
     role: "menuitem",  // Aria role.
 
     Init: function (name,def) {
-      if (!(name instanceof Array)) {name = [name,name]}  // make [id,label] pair
+      if (!(Object.prototype.toString.call(name) === "[object Array]")) {name = [name,name]}  // make [id,label] pair
       this.name = name; this.With(def);
     },
     Label: function (def,menu) {

--- a/unpacked/extensions/TeX/begingroup.js
+++ b/unpacked/extensions/TeX/begingroup.js
@@ -118,7 +118,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
         //  so they can be made global when merged with the root stack.
         //
         while (n > 0) {this.stack[n].Undef(name,type); n--}
-        if (!(value instanceof Array)) {value = [value]}
+        if (!(Object.prototype.toString.call(value) === "[object Array]")) {value = [value]}
         if (this.isEqn) {value.global = true}
       }
       this.stack[n].Def(name,value,type);

--- a/unpacked/extensions/TeX/newcommand.js
+++ b/unpacked/extensions/TeX/newcommand.js
@@ -97,7 +97,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
       var cs     = this.GetCSname(name),
           params = this.GetTemplate(name,"\\"+cs),
           def    = this.GetArgument(name);
-      if (!(params instanceof Array)) {this.setDef(cs,['Macro',def,params])}
+      if (!(Object.prototype.toString.call(params) === "[object Array]")) {this.setDef(cs,['Macro',def,params])}
         else {this.setDef(cs,['MacroWithTemplate',def].concat(params))}
     },
     

--- a/unpacked/jax/input/MathML/jax.js
+++ b/unpacked/jax/input/MathML/jax.js
@@ -288,7 +288,7 @@
       //
       //  Translate message if it is ["id","message",args]
       //
-      if (message instanceof Array) {message = _.apply(_,message)}
+      if (Object.prototype.toString.call(message) === "[object Array]") {message = _.apply(_,message)}
       throw MathJax.Hub.Insert(Error(message),{mathmlError: true});
     },
     //

--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -48,7 +48,7 @@
         if (item instanceof MML.mbase) {item = STACKITEM.mml(item)}
         item.global = this.global;
         top = (this.data.length ? this.Top().checkItem(item) : true);
-        if (top instanceof Array) {this.Pop(); this.Push.apply(this,top)}
+        if (Object.prototype.toString.call(top) === "[object Array]") {this.Pop(); this.Push.apply(this,top)}
         else if (top instanceof STACKITEM) {this.Pop(); this.Push(top)}
         else if (top) {
           this.data.push(item);
@@ -1103,7 +1103,7 @@
     ControlSequence: function (c) {
       var name = this.GetCS(), macro = this.csFindMacro(name);
       if (macro) {
-        if (!(macro instanceof Array)) {macro = [macro]}
+        if (!(Object.prototype.toString.call(macro) === "[object Array]")) {macro = [macro]}
         var fn = macro[0]; if (!(fn instanceof Function)) {fn = this[fn]}
         fn.apply(this,[c+name].concat(macro.slice(1)));
       } else if (TEXDEF.mathchar0mi[name])            {this.csMathchar0mi(name,TEXDEF.mathchar0mi[name])}
@@ -1122,7 +1122,7 @@
     //
     csMathchar0mi: function (name,mchar) {
       var def = {mathvariant: MML.VARIANT.ITALIC};
-      if (mchar instanceof Array) {def = mchar[1]; mchar = mchar[0]}
+      if (Object.prototype.toString.call(mchar) === "[object Array]") {def = mchar[1]; mchar = mchar[0]}
       this.Push(this.mmlToken(MML.mi(MML.entity("#x"+mchar)).With(def)));
     },
     //
@@ -1130,7 +1130,7 @@
     //
     csMathchar0mo: function (name,mchar) {
       var def = {stretchy: false};
-      if (mchar instanceof Array) {def = mchar[1]; def.stretchy = false; mchar = mchar[0]}
+      if (Object.prototype.toString.call(mchar) === "[object Array]") {def = mchar[1]; def.stretchy = false; mchar = mchar[0]}
       this.Push(this.mmlToken(MML.mo(MML.entity("#x"+mchar)).With(def)));
     },
     //
@@ -1138,7 +1138,7 @@
     //
     csMathchar7: function (name,mchar) {
       var def = {mathvariant: MML.VARIANT.NORMAL};
-      if (mchar instanceof Array) {def = mchar[1]; mchar = mchar[0]}
+      if (Object.prototype.toString.call(mchar) === "[object Array]") {def = mchar[1]; mchar = mchar[0]}
       if (this.stack.env.font) {def.mathvariant = this.stack.env.font}
       this.Push(this.mmlToken(MML.mi(MML.entity("#x"+mchar)).With(def)));
     },
@@ -1147,7 +1147,7 @@
     //
     csDelimiter: function (name,delim) {
       var def = {};
-      if (delim instanceof Array) {def = delim[1]; delim = delim[0]}
+      if (Object.prototype.toString.call(delim) === "[object Array]") {def = delim[1]; delim = delim[0]}
       if (delim.length === 4) {delim = MML.entity('#x'+delim)} else {delim = MML.chars(delim)}
       this.Push(this.mmlToken(MML.mo(delim).With({fence: false, stretchy: false}).With(def)));
     },
@@ -1294,7 +1294,7 @@
       if (this.stack.env.font) {def = {mathvariant: this.stack.env.font}}
       if (TEXDEF.remap[c]) {
         c = TEXDEF.remap[c];
-        if (c instanceof Array) {def = c[1]; c = c[0]}
+        if (Object.prototype.toString.call(c) === "[object Array]") {def = c[1]; c = c[0]}
         mo = MML.mo(MML.entity('#x'+c)).With(def);
       } else {
         mo = MML.mo(c).With(def);
@@ -1789,7 +1789,7 @@
       if (env.match(/\\/i)) {TEX.Error(["InvalidEnv","Invalid environment name '%1'",env])}
       var cmd = this.envFindName(env);
       if (!cmd) {TEX.Error(["UnknownEnv","Unknown environment '%1'",env])}
-      if (!(cmd instanceof Array)) {cmd = [cmd]}
+      if (!(Object.prototype.toString.call(cmd) === "[object Array]")) {cmd = [cmd]}
       var end = (cmd[1] instanceof Array ? cmd[1][0] : cmd[1]);
       var mml = STACKITEM.begin().With({name: env, end: end, parse:this});
       if (name === "\\end") {
@@ -1867,7 +1867,7 @@
     convertDelimiter: function (c) {
       if (c) {c = TEXDEF.delimiter[c]}
       if (c == null) {return null}
-      if (c instanceof Array) {c = c[0]}
+      if (Object.prototype.toString.call(c) === "[object Array]") {c = c[0]}
       if (c.length === 4) {c = String.fromCharCode(parseInt(c,16))}
       return c;
     },
@@ -2199,7 +2199,7 @@
       //
       //  Translate message if it is ["id","message",args]
       //
-      if (message instanceof Array) {message = _.apply(_,message)}
+      if (Object.prototype.toString.call(message) === "[object Array]") {message = _.apply(_,message)}
       throw HUB.Insert(Error(message),{texError: true});
     },
     

--- a/unpacked/jax/output/CommonHTML/autoload/multiline.js
+++ b/unpacked/jax/output/CommonHTML/autoload/multiline.js
@@ -669,7 +669,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       //    use it to modify the default penalty
       //
       var linebreak = PENALTY[values.linebreak||MML.LINEBREAK.AUTO];
-      if (!(linebreak instanceof Array)) {
+      if (!(Object.prototype.toString.call(linebreak) === "[object Array]")) {
         //  for breaks past the width, don't modify penalty
         if (offset >= 0) {penalty = linebreak * info.nest}
       } else {penalty = Math.max(1,penalty + linebreak[0] * info.nest)}
@@ -718,7 +718,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       if (linebreakValue === MML.LINEBREAK.AUTO && w >= PENALTY.spacelimit &&
           !this.mathbackground && !this.background)
         linebreak = [(w+PENALTY.spaceoffset)*PENALTY.spacefactor];
-      if (!(linebreak instanceof Array)) {
+      if (!(Object.prototype.toString.call(linebreak) === "[object Array]")) {
         //  for breaks past the width, don't modify penalty
         if (offset >= 0) {penalty = linebreak * info.nest}
       } else {penalty = Math.max(1,penalty + linebreak[0] * info.nest)}

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -794,7 +794,7 @@
       } else if (this.FONTDATA.REMAP[n] && !variant.noRemap) {
         n = this.FONTDATA.REMAP[n];
       }
-      if (n instanceof Array) {variant = VARIANT[n[1]]; n = n[0]} 
+      if (Object.prototype.toString.call(n) === "[object Array]") {variant = VARIANT[n[1]]; n = n[0]} 
       if (typeof(n) === "string") {
         var string = {text:n, i:0, length:n.length};
         while (string.i < string.length) {
@@ -1033,7 +1033,7 @@
         CHTML.addElement(node,"mjx-box",{style:{width:bbox.w}});
         return bbox;
       }
-      if (!(HW instanceof Array)) HW = [HW,HW];
+      if (!(Object.prototype.toString.call(HW) === "[object Array]")) HW = [HW,HW];
       var hw = HW[1]; HW = HW[0];
       var delim = {alias: code};
       while (delim.alias) {
@@ -1396,7 +1396,7 @@
       CHTMLaddChild: function (node,i,options) {
         var child = this.data[i], cnode;
         var type = options.childNodes;
-        if (type instanceof Array) type = type[i]||"span";
+        if (Object.prototype.toString.call(type) === "[object Array]") type = type[i]||"span";
         if (child) {
           if (type) node = CHTML.addElement(node,type);
           cnode = child.toCommonHTML(node,options.childOptions);
@@ -1943,7 +1943,7 @@
             {H = [Math.max(H*CHTML.TEX.delimiterfactor/1000,H-CHTML.TEX.delimitershortfall),H]}
           while (node.firstChild) node.removeChild(node.firstChild);
           this.CHTML = bbox = CHTML.createDelimiter(node,this.data.join("").charCodeAt(0),H,bbox);
-          bbox.sH = (H instanceof Array ? H[1] : H);
+          bbox.sH = (Object.prototype.toString.call(H) === "[object Array]" ? H[1] : H);
           //
           //  Reposition as needed
           //

--- a/unpacked/jax/output/HTML-CSS/autoload/multiline.js
+++ b/unpacked/jax/output/HTML-CSS/autoload/multiline.js
@@ -686,7 +686,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
       //    use it to modify the default penalty
       //
       var linebreak = PENALTY[values.linebreak||MML.LINEBREAK.AUTO];
-      if (!(linebreak instanceof Array)) {
+      if (!(Object.prototype.toString.call(linebreak) === "[object Array]")) {
         //  for breaks past the width, don't modify penalty
         if (offset >= 0) {penalty = linebreak * info.nest}
       } else {penalty = Math.max(1,penalty + linebreak[0] * info.nest)}
@@ -736,7 +736,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
       if (linebreakValue === MML.LINEBREAK.AUTO && w >= PENALTY.spacelimit &&
           !this.mathbackground && !this.background)
         {linebreak = [(w+PENALTY.spaceoffset)*PENALTY.spacefactor]}
-      if (!(linebreak instanceof Array)) {
+      if (!(Object.prototype.toString.call(linebreak) === "[object Array]")) {
         //  for breaks past the width, don't modify penalty
         if (offset >= 0) {penalty = linebreak * info.nest}
       } else {penalty = Math.max(1,penalty + linebreak[0] * info.nest)}

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -1341,7 +1341,7 @@
         return;
       }
       if (!scale) {scale = 1};
-      if (!(HW instanceof Array)) {HW = [HW,HW]}
+      if (!(Object.prototype.toString.call(HW) === "[object Array]")) {HW = [HW,HW]}
       var hw = HW[1]; HW = HW[0];
       var delim = {alias: code};
       while (delim.alias) {
@@ -1544,7 +1544,7 @@
         } else if (this.FONTDATA.REMAP[n] && !variant.noRemap) {
           n = this.FONTDATA.REMAP[n];
         }
-        if (n instanceof Array) {variant = this.FONTDATA.VARIANT[n[1]]; n = n[0]} 
+        if (Object.prototype.toString.call(n) === "[object Array]") {variant = this.FONTDATA.VARIANT[n[1]]; n = n[0]} 
         if (typeof(n) === "string") {
           text = n+text.substr(i+1);
           m = text.length; i = -1;
@@ -1641,7 +1641,7 @@
       if (!variant.FONTS) {
         var FONTS = this.FONTDATA.FONTS;
         var fonts = (variant.fonts || this.FONTDATA.VARIANT.normal.fonts);
-        if (!(fonts instanceof Array)) {fonts = [fonts]}
+        if (!(Object.prototype.toString.call(fonts) === "[object Array]")) {fonts = [fonts]}
         if (variant.fonts != fonts) {variant.fonts = fonts}
         variant.FONTS = [];
         for (i = 0, m = fonts.length; i < m; i++) {

--- a/unpacked/jax/output/SVG/autoload/multiline.js
+++ b/unpacked/jax/output/SVG/autoload/multiline.js
@@ -606,7 +606,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       //    use it to modify the default penalty
       //
       var linebreak = PENALTY[values.linebreak||MML.LINEBREAK.AUTO];
-      if (!(linebreak instanceof Array)) {
+      if (!(Object.prototype.toString.call(linebreak) === "[object Array]")) {
         //  for breaks past the width, don't modify penalty
         if (offset >= 0) {penalty = linebreak * info.nest}
       } else {penalty = Math.max(1,penalty + linebreak[0] * info.nest)}
@@ -655,7 +655,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       if (linebreakValue === MML.LINEBREAK.AUTO && w >= PENALTY.spacelimit*1000 &&
           !this.mathbackground && !this.backrgound)
         {linebreak = [(w/1000+PENALTY.spaceoffset)*PENALTY.spacefactor]}
-      if (!(linebreak instanceof Array)) {
+      if (!(Object.prototype.toString.call(linebreak) === "[object Array]")) {
         //  for breaks past the width, don't modify penalty
         if (offset >= 0) {penalty = linebreak * info.nest}
       } else {penalty = Math.max(1,penalty + linebreak[0] * info.nest)}

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -621,7 +621,7 @@
         } else if (this.FONTDATA.REMAP[n] && !variant.noRemap) {
           n = this.FONTDATA.REMAP[n];
         }
-        if (n instanceof Array) {variant = this.FONTDATA.VARIANT[n[1]]; n = n[0]}
+        if (Object.prototype.toString.call(n) === "[object Array]") {variant = this.FONTDATA.VARIANT[n[1]]; n = n[0]}
         if (typeof(n) === "string") {
           text = n+text.substr(i+1);
           m = text.length; i = -1;
@@ -665,7 +665,7 @@
       if (!variant.FONTS) {
         var FONTS = this.FONTDATA.FONTS;
         var fonts = (variant.fonts || this.FONTDATA.VARIANT.normal.fonts);
-        if (!(fonts instanceof Array)) {fonts = [fonts]}
+        if (!(Object.prototype.toString.call(fonts) === "[object Array]")) {fonts = [fonts]}
         if (variant.fonts != fonts) {variant.fonts = fonts}
         variant.FONTS = [];
         for (i = 0, m = fonts.length; i < m; i++) {
@@ -707,7 +707,7 @@
         svg.w = svg.r = this.TeX.nulldelimiterspace * scale;
         return svg;
       }
-      if (!(HW instanceof Array)) {HW = [HW,HW]}
+      if (!(Object.prototype.toString.call(HW) === "[object Array]")) {HW = [HW,HW]}
       var hw = HW[1]; HW = HW[0];
       var delim = {alias: code};
       while (delim.alias) {


### PR DESCRIPTION
This PR should help resolve https://github.com/mathjax/MathJax/issues/1584.

I considered using `Array.isArray`, but because this is an ES5 feature it might not work with older browsers. This could be implemented with a simple polyfill (e.g. just by adding this method to the `Array` prototype) but not sure if this is a desirable solution for MathJax.