### PR TITLE
Make sure trimSpaces() doesn't remove tailing space in '\ '.  #1586

### DIFF
--- a/unpacked/extensions/TeX/newcommand.js
+++ b/unpacked/extensions/TeX/newcommand.js
@@ -51,12 +51,11 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
      *  Implement \newcommand{\name}[n][default]{...}
      */
     NewCommand: function (name) {
-      var CS = this.GetArgument(name), cs = this.trimSpaces(CS),
+      var cs = this.trimSpaces(this.GetArgument(name)),
           n  = this.GetBrackets(name),
           opt = this.GetBrackets(name),
           def = this.GetArgument(name);
       if (cs.charAt(0) === "\\") {cs = cs.substr(1)}
-      if (cs === "" && CS.substr(CS.length-1,1) === " ") {cs += " "}
       if (!cs.match(/^(.|[a-z]+)$/i)) {
         TEX.Error(["IllegalControlSequenceName",
                    "Illegal control sequence name for %1",name]);
@@ -147,9 +146,8 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
         TEX.Error(["MissingCS",
                    "%1 must be followed by a control sequence", cmd])
       }
-      var cs = this.GetArgument(cmd), CS = this.trimSpaces(cs);
-      if (CS == "\\" && cs.substr(cs.length-1,1) === " ") {CS += " "}
-      return CS.substr(1);
+      var cs = this.trimSpaces(this.GetArgument(cmd));
+      return cs.substr(1);
     },
     
     /*

--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -1877,7 +1877,9 @@
      */
     trimSpaces: function (text) {
       if (typeof(text) != 'string') {return text}
-      return text.replace(/^\s+|\s+$/g,'');
+      var TEXT = text.replace(/^\s+|\s+$/g,'');
+      if (TEXT.match(/\\$/) && text.match(/ $/)) TEXT += " ";
+      return TEXT;
     },
 
     /*


### PR DESCRIPTION
Make sure trimSpaces() doesn't remove tailing space in '\ '.  Resolves issue #1586 (and handles #1563 better).