### PR TITLE
Set previews to have display:none.  #1555

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -2306,7 +2306,10 @@ MathJax.Hub = {
         result = MathJax.OutputJax[jax.outputJax].Process(script,state);
         if (result !== false) {
           script.MathJax.state = STATE.PROCESSED;
-          if (script.MathJax.preview) {script.MathJax.preview.innerHTML = ""}
+          if (script.MathJax.preview) {
+            script.MathJax.preview.innerHTML = "";
+            script.MathJax.preview.style.display = "none";
+          }
           //
           //  Signal that new math is available
           //
@@ -2390,7 +2393,10 @@ MathJax.Hub = {
     var node = document.getElementById(error.id);
     if (node) node.parentNode.removeChild(node);
     if (script.parentNode) script.parentNode.insertBefore(error,script);
-    if (script.MathJax.preview) {script.MathJax.preview.innerHTML = ""}
+    if (script.MathJax.preview) {
+      script.MathJax.preview.innerHTML = "";
+      script.MathJax.preview.style.display = "none";
+    }
     //
     //  Save the error for debugging purposes
     //  Report the error as a signal

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -603,6 +603,7 @@
           //
           if (data.preview) {
             data.preview.innerHTML = "";
+            data.preview.style.display = "none";
             script.MathJax.preview = data.preview;
             delete data.preview;
           }

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -765,7 +765,10 @@
         if (script && script.parentNode && script.MathJax.elementJax) {
           var div = (script.MathJax.elementJax.HTMLCSS||{}).div;
           if (div) {div.className = div.className.split(/ /)[0]}
-          if (script.MathJax.preview) {script.MathJax.preview.innerHTML = ""}
+          if (script.MathJax.preview) {
+            script.MathJax.preview.innerHTML = "";
+            script.MathJax.preview.style.display = "none";
+          }
         }
       }
       //

--- a/unpacked/jax/output/PreviewHTML/jax.js
+++ b/unpacked/jax/output/PreviewHTML/jax.js
@@ -268,6 +268,7 @@
           //
           if (data.preview) {
             data.preview.innerHTML = "";
+            data.preview.style.display = "none";
             script.MathJax.preview = data.preview;
             delete data.preview;
           }

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -386,6 +386,7 @@
           //
           if (data.preview) {
             data.preview.innerHTML = "";
+            data.preview.style.display = "none";
             script.MathJax.preview = data.preview;
             delete data.preview;
           }


### PR DESCRIPTION
Set previews to have `display:none` when their expressions have been typeset.  This avoids the problem with Firefox where the preview causes an extra line break when a displayed equation appears as the first thing in a list.

Resolves issue #1555.