### PR TITLE
Change 'rev=' to 'V=' in cache breaking code.  #1570

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -705,9 +705,9 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
     //  Cache-breaking revision number for file
     //
     fileRev: function (file) {
-      var rev = BASE.cdnFileVersions[file] || BASE.cdnVersion || '';
-      if (rev) {rev = "?rev="+rev}
-      return rev;
+      var V = BASE.cdnFileVersions[file] || BASE.cdnVersion || '';
+      if (V) {V = "?V="+V}
+      return V;
     },
     urlRev: function (file) {return this.fileURL(file)+this.fileRev(file)},
     


### PR DESCRIPTION
Change `rev=` to `V=` in cache breaking code (hoping this doesn't conflict with any web server's usage, as `rev=` did).

Resolves issue #1570.