### PR TITLE
Handle \ref properly when there is a <base> tag.  #1589

### DIFF
--- a/unpacked/config/default.js
+++ b/unpacked/config/default.js
@@ -550,7 +550,8 @@ MathJax.Hub.Config({
 //    formatTag:    function (n) {return '('+n+')'},        // format for \tag and \eqref
 //    formatID:     function (n) {return 'mjx-eqn-'+String(n).replace(/[:'"<>&]/g,"")},
 //                                                          // element ID to use for reference
-//    formatURL:    function (id) {return '#'+escape(id)},  // URL to use for references
+//    formatURL:    function (id,base) {return base+'#'+escape(id)},
+//                                                          // URL to use for references
       useLabelIds: true    // make element ID's use \label name rather than equation number
     },
 

--- a/unpacked/extensions/TeX/AMSmath.js
+++ b/unpacked/extensions/TeX/AMSmath.js
@@ -53,6 +53,14 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
     return WW.join(" ");
   };
   
+  //
+  //  Get the URL of the page (for use with formatURL) when there
+  //  is a <base> element on the page.
+  //  
+  var baseURL = (document.getElementsByTagName("base").length === 0) ? "" :
+                String(document.location).replace(/#.*$/,"");
+
+  
   /******************************************************************************/
   
   TEXDEF.Add({
@@ -203,7 +211,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
       if (!ref) {ref = {tag:"???",id:""}; AMS.badref = !AMS.refUpdate}
       var tag = ref.tag; if (eqref) {tag = CONFIG.formatTag(tag)}
       this.Push(MML.mrow.apply(MML,this.InternalMath(tag)).With({
-        href:CONFIG.formatURL(ref.id), "class":"MathJax_ref"
+        href:CONFIG.formatURL(ref.id,baseURL), "class":"MathJax_ref"
       }));
     },
     

--- a/unpacked/jax/input/TeX/config.js
+++ b/unpacked/jax/input/TeX/config.js
@@ -42,7 +42,7 @@ MathJax.InputJax.TeX = MathJax.InputJax({
       formatNumber: function (n) {return n},
       formatTag:    function (n) {return '('+n+')'},
       formatID:     function (n) {return 'mjx-eqn-'+String(n).replace(/[:"'<>&]/g,"")},
-      formatURL:    function (id) {return '#'+escape(id)},
+      formatURL:    function (id,base) {return base+'#'+escape(id)},
       useLabelIds:  true
     }
   },


### PR DESCRIPTION
Handle references (`\ref` and `\eqref`) properly when there is a `<base>` tag.  Resolves issue #1589.