### PR TITLE
Add MathJax.Object.isArray, and change most 'instanceof Array' to use it.  #1584

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -155,7 +155,7 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
     })
   });
   
-  BASE.Object.isArray = function (obj) {
+  BASE.Object.isArray = Array.isArray || function (obj) {
     return Object.prototype.toString.call(obj) === "[object Array]";
   };
   

--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -154,6 +154,12 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
 
     })
   });
+  
+  BASE.Object.isArray = function (obj) {
+    return Object.prototype.toString.call(obj) === "[object Array]";
+  };
+  
+  BASE.Object.Array = Array;
 
 })("MathJax");
 
@@ -211,6 +217,7 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
 (function (BASENAME) {
   var BASE = window[BASENAME];
   if (!BASE) {BASE = window[BASENAME] = {}}
+  var isArray = BASE.Object.isArray;
   //
   //  Create a callback from an associative array
   //
@@ -279,8 +286,8 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
       }
     }
     TESTEVAL = null;
-  }
-
+  };
+  
   //
   //  Create a callback from various types of data
   //
@@ -291,11 +298,11 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
             {args = [].slice.call(args,i)}
       else {args = [].slice.call(arguments,0)}
     }
-    if (args instanceof Array && args.length === 1) {args = args[0]}
+    if (isArray(args) && args.length === 1) {args = args[0]}
     if (typeof args === 'function') {
       if (args.execute === CALLBACK.prototype.execute) {return args}
       return CALLBACK({hook: args});
-    } else if (args instanceof Array) {
+    } else if (isArray(args)) {
       if (typeof(args[0]) === 'string' && args[1] instanceof Object &&
                  typeof args[1][args[0]] === 'function') {
         return CALLBACK({hook: args[1][args[0]], object: args[1], data: args.slice(2)});
@@ -343,7 +350,7 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
     }
   };
   var WAITSIGNAL = function (callback,signals) {
-    if (!(signals instanceof Array)) {signals = [signals]}
+    if (!isArray(signals)) {signals = [signals]}
     if (!callback.signal) {
       callback.oldExecute = callback.execute;
       callback.execute = WAITEXECUTE;
@@ -442,8 +449,8 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
   //
   var EXECUTEHOOKS = function (hooks,data,reset) {
     if (!hooks) {return null}
-    if (!(hooks instanceof Array)) {hooks = [hooks]}
-    if (!(data instanceof Array))  {data = (data == null ? [] : [data])}
+    if (!isArray(hooks)) {hooks = [hooks]}
+    if (!isArray(data))  {data = (data == null ? [] : [data])}
     var handler = HOOKS(reset);
     for (var i = 0, m = hooks.length; i < m; i++) {handler.Add(hooks[i])}
     return handler.Execute.apply(handler,data);
@@ -592,7 +599,7 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
     //  Execute the message hooks for the given message
     //
     ExecuteHooks: function (msg) {
-      var type = ((msg instanceof Array) ? msg[0] : msg);
+      var type = (isArray(msg) ? msg[0] : msg);
       if (!this.hooks[type]) {return null}
       return this.hooks[type].Execute(msg);
     },
@@ -1003,7 +1010,7 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
       for (id in styles) {if (styles.hasOwnProperty(id)) {
         if (typeof styles[id] === 'string') {
           string += id + " {"+styles[id]+"}\n";
-        } else if (styles[id] instanceof Array) {
+        } else if (BASE.Object.isArray(styles[id])) {
           for (var i = 0; i < styles[id].length; i++) {
             style = {}; style[id] = styles[id][i];
             string += this.StyleString(style);
@@ -1055,9 +1062,9 @@ MathJax.HTML = {
       }
     }
     if (contents) {
-      if (!(contents instanceof Array)) {contents = [contents]}
+      if (!MathJax.Object.isArray(contents)) {contents = [contents]}
       for (var i = 0, m = contents.length; i < m; i++) {
-        if (contents[i] instanceof Array) {
+        if (MathJax.Object.isArray(contents[i])) {
           obj.appendChild(this.Element(contents[i][0],contents[i][1],contents[i][2]));
         } else if (type === "script") { // IE throws an error if script is added as a text node
           this.setScript(obj, contents[i]);
@@ -1220,7 +1227,7 @@ MathJax.Localization = {
     }),
   
   _: function (id,phrase) {
-    if (phrase instanceof Array) {return this.processSnippet(id,phrase)}
+    if (MathJax.Object.isArray(phrase)) {return this.processSnippet(id,phrase)}
     return this.processString(this.lookupPhrase(id,phrase),[].slice.call(arguments,2));
   },
   
@@ -1230,9 +1237,9 @@ MathJax.Localization = {
     //    If the argument is a snippet (and we are processing snippets) do so,
     //    Otherwise, if it is a number, convert it for the lacale
     //
-    var i, m;
+    var i, m, isArray = MathJax.Object.isArray;
     for (i = 0, m = args.length; i < m; i++) {
-      if (domain && args[i] instanceof Array) {args[i] = this.processSnippet(domain,args[i])}
+      if (domain && isArray(args[i])) {args[i] = this.processSnippet(domain,args[i])}
     }
     //
     //  Split string at escapes and process them individually
@@ -1282,7 +1289,7 @@ MathJax.Localization = {
     for (i = 0; i < m; i++) {
       part += parts[i]; i++;  // add the string and move on to substitution result
       if (i < m) {
-        if (parts[i] instanceof Array)  {        // substitution was a snippet
+        if (isArray(parts[i]))  {                // substitution was a snippet
           snippet.push(part);                        // add the accumulated string
           snippet = snippet.concat(parts[i]);        // concatenate the substution snippet
           part = "";                                 // start accumulating a new string
@@ -1302,7 +1309,7 @@ MathJax.Localization = {
     //   strings or snippets to translate
     //
     for (var i = 0, m = snippet.length; i < m; i++) {
-      if (snippet[i] instanceof Array) {
+      if (MathJax.Object.isArray(snippet[i])) {
         //
         //  This could be a sub-snippet:
         //    ["tag"] or ["tag",{properties}] or ["tag",{properties},snippet]
@@ -1310,10 +1317,10 @@ MathJax.Localization = {
         //    [id,string,args] or [domain,snippet]
         var data = snippet[i];
         if (typeof data[1] === "string") {        // [id,string,args]
-          var id = data[0]; if (!(id instanceof Array)) {id = [domain,id]}
+          var id = data[0]; if (!MathJax.Object.isArray(id)) {id = [domain,id]}
           var phrase = this.lookupPhrase(id,data[1]);
           result = result.concat(this.processMarkdown(phrase,data.slice(2),domain));
-        } else if (data[1] instanceof Array) {    // [domain,snippet]
+        } else if (MathJax.Object.isArray(data[1])) {    // [domain,snippet]
           result = result.concat(this.processSnippet.apply(this,data));
         } else if (data.length >= 3) {            // ["tag",{properties},snippet]
           result.push([data[0],data[1],this.processSnippet(domain,data[2])]);
@@ -1349,7 +1356,7 @@ MathJax.Localization = {
         //  Select the tag to use by number of stars (three stars requires two tags)
         //
         data = this.processString(parts[i+2],args,domain);
-        if (!(data instanceof Array)) {data = [data]}
+        if (!MathJax.Object.isArray(data)) {data = [data]}
         data = [["b","i","i"][parts[i+1].length-1],{},data]; // number of stars determines type
         if (parts[i+1].length === 3) {data = ["b",{},data]}  // bold-italic
       } else if (parts[i+3]) { //  backtics (for code)
@@ -1358,14 +1365,14 @@ MathJax.Localization = {
         //  Make a <code> tag
         //
         data = this.processString(parts[i+4].replace(/^\s/,"").replace(/\s$/,""),args,domain);
-        if (!(data instanceof Array)) {data = [data]}
+        if (!MathJax.Object.isArray(data)) {data = [data]}
         data = ["code",{},data];
       } else if (parts[i+5]) { //  hyperlink
         //
         //  Process the link text, and make an <a> tag with the URL
         //
         data = this.processString(parts[i+5],args,domain);
-        if (!(data instanceof Array)) {data = [data]}
+        if (!MathJax.Object.isArray(data)) {data = [data]}
         data = ["a",{href:this.processString(parts[i+6],args),target:"_blank"},data];
       } else {
         //
@@ -1400,7 +1407,7 @@ MathJax.Localization = {
       //  Then concatenate the snippet to the current one
       //
       string = this.processString(string,args,domain);
-      if (!(string instanceof Array)) {string = [string]}
+      if (!MathJax.Object.isArray(string)) {string = [string]}
       result = result.concat(string);
     }
     return result;
@@ -1411,7 +1418,7 @@ MathJax.Localization = {
     //  Get the domain and messageID
     //
     if (!domain) {domain = "_"}
-    if (id instanceof Array) {domain = (id[0] || "_"); id = (id[1] || "")}
+    if (MathJax.Object.isArray(id)) {domain = (id[0] || "_"); id = (id[1] || "")}
     //
     //  Check if the data is available and if not,
     //    load it and throw a restart error so the calling
@@ -1725,8 +1732,8 @@ MathJax.Message = {
     //  Translate message if it is [id,message,arguments]
     //
     var id = "";
-    if (text instanceof Array) {
-      id = text[0]; if (id instanceof Array) {id = id[1]}
+    if (MathJax.Object.isArray(text)) {
+      id = text[0]; if (MathJax.Object.isArray(id)) {id = id[1]}
       //
       // Localization._() will throw a restart error if a localization file
       //   needs to be loaded, so trap that and redo the Set() call
@@ -2411,11 +2418,11 @@ MathJax.Hub = {
   },
   
   elementCallback: function (element,callback) {
-    if (callback == null && (element instanceof Array || typeof element === 'function'))
+    if (callback == null && (MathJax.Object.isArray(element) || typeof element === 'function'))
       {try {MathJax.Callback(element); callback = element; element = null} catch(e) {}}
     if (element == null) {element = this.config.elements || []}
     if (this.isHTMLCollection(element)) {element = this.HTMLCollection2Array(element)}
-    if (!(element instanceof Array)) {element = [element]}
+    if (!MathJax.Object.isArray(element)) {element = [element]}
     element = [].concat(element); // make a copy so the original isn't changed
     for (var i = 0, m = element.length; i < m; i++)
       {if (typeof(element[i]) === 'string') {element[i] = document.getElementById(element[i])}}
@@ -2431,7 +2438,7 @@ MathJax.Hub = {
   
   elementScripts: function (element) {
     var scripts = [];
-    if (element instanceof Array || this.isHTMLCollection(element)) {
+    if (MathJax.Object.isArray(element) || this.isHTMLCollection(element)) {
       for (var i = 0, m = element.length; i < m; i++) {
         var alreadyDone = 0;
         for (var j = 0; j < i && !alreadyDone; j++)
@@ -2468,7 +2475,7 @@ MathJax.Hub = {
   Insert: function (dst,src) {
     for (var id in src) {if (src.hasOwnProperty(id)) {
       // allow for concatenation of arrays?
-      if (typeof src[id] === 'object' && !(src[id] instanceof Array) &&
+      if (typeof src[id] === 'object' && !(MathJax.Object.isArray(src[id])) &&
          (typeof dst[id] === 'object' || typeof dst[id] === 'function')) {
         this.Insert(dst[id],src[id]);
       } else {
@@ -2785,7 +2792,7 @@ MathJax.Hub.Startup = {
   //
   loadArray: function (files,dir,name,synchronous) {
     if (files) {
-      if (!(files instanceof Array)) {files = [files]}
+      if (!MathJax.Object.isArray(files)) {files = [files]}
       if (files.length) {
         var queue = MathJax.Callback.Queue(), callback = {}, file;
         for (var i = 0, m = files.length; i < m; i++) {
@@ -2895,11 +2902,11 @@ MathJax.Hub.Startup = {
     Process: function (script,state) {
       var queue = CALLBACK.Queue(), file;
       // Load any needed element jax
-      var jax = this.elementJax; if (!(jax instanceof Array)) {jax = [jax]}
+      var jax = this.elementJax; if (!BASE.Object.isArray(jax)) {jax = [jax]}
       for (var i = 0, m = jax.length; i < m; i++) {
         file = BASE.ElementJax.directory+"/"+jax[i]+"/"+this.JAXFILE;
         if (!this.require) {this.require = []}
-          else if (!(this.require instanceof Array)) {this.require = [this.require]};
+          else if (!BASE.Object.isArray(this.require)) {this.require = [this.require]};
         this.require.push(file);  // so Startup will wait for it to be loaded
         queue.Push(AJAX.Require(file));
       }
@@ -2954,7 +2961,7 @@ MathJax.Hub.Startup = {
         {jax[mimetype].unshift(this)} else {jax[mimetype].push(this)}
       //  Make sure the element jax is loaded before Startup is called
       if (!this.require) {this.require = []}
-        else if (!(this.require instanceof Array)) {this.require = [this.require]};
+        else if (!BASE.Object.isArray(this.require)) {this.require = [this.require]};
       this.require.push(BASE.ElementJax.directory+"/"+(mimetype.split(/\//)[1])+"/"+this.JAXFILE);
     },
     Remove: function (jax) {}

--- a/unpacked/extensions/FontWarnings.js
+++ b/unpacked/extensions/FontWarnings.js
@@ -247,7 +247,7 @@
     } else {delete CONFIG.messageStyle.filter}
     CONFIG.messageStyle.maxWidth = (document.body.clientWidth-75) + "px";
     var i = 0; while (i < data.length) {
-      if (data[i] instanceof Array) {
+      if (MathJax.Object.isArray(data[i])) {
         if (data[i].length === 1 && CONFIG.HTML[data[i][0]]) {
           data.splice.apply(data,[i,1].concat(CONFIG.HTML[data[i][0]]));
         } else if (typeof data[i][1] === "string") {

--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -42,6 +42,8 @@
       [["MathMenu",id]].concat([].slice.call(arguments,1))
     );
   };
+  
+  var isArray = MathJax.Object.isArray;
 
   var isPC = HUB.Browser.isPC, isMSIE = HUB.Browser.isMSIE, isIE9 = ((document.documentMode||0) > 8);
   var ROUND = (isPC ? null : "5px");
@@ -806,7 +808,7 @@
     action: function () {},
 
     Init: function (name,action,def) {
-      if (!(name instanceof Array)) {name = [name,name]}  // make [id,label] pair
+      if (!isArray(name)) {name = [name,name]}  // make [id,label] pair
       this.name = name; this.action = action;
       this.With(def);
     },
@@ -837,7 +839,7 @@
       return def;
     },
     Init: function (name,def) {
-      if (!(name instanceof Array)) {name = [name,name]}  // make [id,label] pair
+      if (!isArray(name)) {name = [name,name]}  // make [id,label] pair
       this.name = name; var i = 1;
       if (!(def instanceof MENU.ITEM)) {this.With(def), i++}
       this.submenu = MENU.apply(MENU,[].slice.call(arguments,i));
@@ -936,7 +938,7 @@
       return def;
     },
     Init: function (name,variable,def) {
-      if (!(name instanceof Array)) {name = [name,name]}  // make [id,label] pair
+      if (!isArray(name)) {name = [name,name]}  // make [id,label] pair
       this.name = name; this.variable = variable; this.With(def);
       if (this.value == null) {this.value = this.name[0]}
     },
@@ -983,7 +985,7 @@
       return def;
     },
     Init: function (name,variable,def) {
-      if (!(name instanceof Array)) {name = [name,name]}  // make [id,label] pair
+      if (!isArray(name)) {name = [name,name]}  // make [id,label] pair
       this.name = name; this.variable = variable; this.With(def);
     },
     Label: function (def,menu) {
@@ -1012,7 +1014,7 @@
     role: "menuitem",  // Aria role.
 
     Init: function (name,def) {
-      if (!(name instanceof Array)) {name = [name,name]}  // make [id,label] pair
+      if (!isArray(name)) {name = [name,name]}  // make [id,label] pair
       this.name = name; this.With(def);
     },
     Label: function (def,menu) {

--- a/unpacked/extensions/Safe.js
+++ b/unpacked/extensions/Safe.js
@@ -227,7 +227,7 @@
       value = this.length2em(value);
       if (value == null) return false;
       var mM = [-CONFIG.lengthMax,CONFIG.lengthMax];
-      if (CONFIG.styleLengths[name] instanceof Array) mM = CONFIG.styleLengths[name];
+      if (MathJax.Object.isArray(CONFIG.styleLengths[name])) mM = CONFIG.styleLengths[name];
       return (value >= mM[0] && value <= mM[1]);
     },
     //

--- a/unpacked/extensions/TeX/begingroup.js
+++ b/unpacked/extensions/TeX/begingroup.js
@@ -118,7 +118,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
         //  so they can be made global when merged with the root stack.
         //
         while (n > 0) {this.stack[n].Undef(name,type); n--}
-        if (!(value instanceof Array)) {value = [value]}
+        if (!MathJax.Object.isArray(value)) {value = [value]}
         if (this.isEqn) {value.global = true}
       }
       this.stack[n].Def(name,value,type);

--- a/unpacked/jax/input/MathML/jax.js
+++ b/unpacked/jax/input/MathML/jax.js
@@ -289,7 +289,7 @@
       //
       //  Translate message if it is ["id","message",args]
       //
-      if (message instanceof Array) {message = _.apply(_,message)}
+      if (MathJax.Object.isArray(message)) {message = _.apply(_,message)}
       throw MathJax.Hub.Insert(Error(message),{mathmlError: true});
     },
     //

--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -33,6 +33,8 @@
     return MathJax.Localization._.apply(MathJax.Localization,
       [["TeX", id]].concat([].slice.call(arguments,1)));
   };
+  
+  var isArray = MathJax.Object.isArray;
 
   var STACK = MathJax.Object.Subclass({
     Init: function (env,inner) {
@@ -414,7 +416,7 @@
     Add: function (src,dst,nouser) {
       if (!dst) {dst = this}
       for (var id in src) {if (src.hasOwnProperty(id)) {
-        if (typeof src[id] === 'object' && !(src[id] instanceof Array) &&
+        if (typeof src[id] === 'object' && !isArray(src[id]) &&
            (typeof dst[id] === 'object' || typeof dst[id] === 'function')) 
              {this.Add(src[id],dst[id],src[id],nouser)}
           else if (!dst[id] || !dst[id].isUser || !nouser) {dst[id] = src[id]}
@@ -1103,7 +1105,7 @@
     ControlSequence: function (c) {
       var name = this.GetCS(), macro = this.csFindMacro(name);
       if (macro) {
-        if (!(macro instanceof Array)) {macro = [macro]}
+        if (!isArray(macro)) {macro = [macro]}
         var fn = macro[0]; if (!(fn instanceof Function)) {fn = this[fn]}
         fn.apply(this,[c+name].concat(macro.slice(1)));
       } else if (TEXDEF.mathchar0mi[name])            {this.csMathchar0mi(name,TEXDEF.mathchar0mi[name])}
@@ -1122,7 +1124,7 @@
     //
     csMathchar0mi: function (name,mchar) {
       var def = {mathvariant: MML.VARIANT.ITALIC};
-      if (mchar instanceof Array) {def = mchar[1]; mchar = mchar[0]}
+      if (isArray(mchar)) {def = mchar[1]; mchar = mchar[0]}
       this.Push(this.mmlToken(MML.mi(MML.entity("#x"+mchar)).With(def)));
     },
     //
@@ -1130,7 +1132,7 @@
     //
     csMathchar0mo: function (name,mchar) {
       var def = {stretchy: false};
-      if (mchar instanceof Array) {def = mchar[1]; def.stretchy = false; mchar = mchar[0]}
+      if (isArray(mchar)) {def = mchar[1]; def.stretchy = false; mchar = mchar[0]}
       this.Push(this.mmlToken(MML.mo(MML.entity("#x"+mchar)).With(def)));
     },
     //
@@ -1138,7 +1140,7 @@
     //
     csMathchar7: function (name,mchar) {
       var def = {mathvariant: MML.VARIANT.NORMAL};
-      if (mchar instanceof Array) {def = mchar[1]; mchar = mchar[0]}
+      if (isArray(mchar)) {def = mchar[1]; mchar = mchar[0]}
       if (this.stack.env.font) {def.mathvariant = this.stack.env.font}
       this.Push(this.mmlToken(MML.mi(MML.entity("#x"+mchar)).With(def)));
     },
@@ -1147,7 +1149,7 @@
     //
     csDelimiter: function (name,delim) {
       var def = {};
-      if (delim instanceof Array) {def = delim[1]; delim = delim[0]}
+      if (isArray(delim)) {def = delim[1]; delim = delim[0]}
       if (delim.length === 4) {delim = MML.entity('#x'+delim)} else {delim = MML.chars(delim)}
       this.Push(this.mmlToken(MML.mo(delim).With({fence: false, stretchy: false}).With(def)));
     },
@@ -1294,7 +1296,7 @@
       if (this.stack.env.font) {def = {mathvariant: this.stack.env.font}}
       if (TEXDEF.remap[c]) {
         c = TEXDEF.remap[c];
-        if (c instanceof Array) {def = c[1]; c = c[0]}
+        if (isArray(c)) {def = c[1]; c = c[0]}
         mo = MML.mo(MML.entity('#x'+c)).With(def);
       } else {
         mo = MML.mo(c).With(def);
@@ -1789,11 +1791,11 @@
       if (env.match(/\\/i)) {TEX.Error(["InvalidEnv","Invalid environment name '%1'",env])}
       var cmd = this.envFindName(env);
       if (!cmd) {TEX.Error(["UnknownEnv","Unknown environment '%1'",env])}
-      if (!(cmd instanceof Array)) {cmd = [cmd]}
-      var end = (cmd[1] instanceof Array ? cmd[1][0] : cmd[1]);
+      if (!isArray(cmd)) {cmd = [cmd]}
+      var end = (isArray(cmd[1]) ? cmd[1][0] : cmd[1]);
       var mml = STACKITEM.begin().With({name: env, end: end, parse:this});
       if (name === "\\end") {
-        if (!isEnd && cmd[1] instanceof Array && this[cmd[1][1]]) {
+        if (!isEnd && isArray(cmd[1]) && this[cmd[1][1]]) {
           mml = this[cmd[1][1]].apply(this,[mml].concat(cmd.slice(2)));
         } else {
           mml = STACKITEM.end().With({name: env});
@@ -1867,7 +1869,7 @@
     convertDelimiter: function (c) {
       if (c) {c = TEXDEF.delimiter[c]}
       if (c == null) {return null}
-      if (c instanceof Array) {c = c[0]}
+      if (isArray(c)) {c = c[0]}
       if (c.length === 4) {c = String.fromCharCode(parseInt(c,16))}
       return c;
     },
@@ -2201,7 +2203,7 @@
       //
       //  Translate message if it is ["id","message",args]
       //
-      if (message instanceof Array) {message = _.apply(_,message)}
+      if (isArray(message)) {message = _.apply(_,message)}
       throw HUB.Insert(Error(message),{texError: true});
     },
     

--- a/unpacked/jax/output/CommonHTML/autoload/multiline.js
+++ b/unpacked/jax/output/CommonHTML/autoload/multiline.js
@@ -669,7 +669,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       //    use it to modify the default penalty
       //
       var linebreak = PENALTY[values.linebreak||MML.LINEBREAK.AUTO];
-      if (!(linebreak instanceof Array)) {
+      if (!MathJax.Object.isArray(linebreak)) {
         //  for breaks past the width, don't modify penalty
         if (offset >= 0) {penalty = linebreak * info.nest}
       } else {penalty = Math.max(1,penalty + linebreak[0] * info.nest)}
@@ -718,7 +718,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       if (linebreakValue === MML.LINEBREAK.AUTO && w >= PENALTY.spacelimit &&
           !this.mathbackground && !this.background)
         linebreak = [(w+PENALTY.spaceoffset)*PENALTY.spacefactor];
-      if (!(linebreak instanceof Array)) {
+      if (!MathJax.Object.isArray(linebreak)) {
         //  for breaks past the width, don't modify penalty
         if (offset >= 0) {penalty = linebreak * info.nest}
       } else {penalty = Math.max(1,penalty + linebreak[0] * info.nest)}

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -30,6 +30,7 @@
 
 (function (AJAX,HUB,HTML,CHTML) {
   var MML;
+  var isArray = MathJax.Object.isArray;
 
   var EVENT, TOUCH, HOVER; // filled in later
 
@@ -799,7 +800,7 @@
       } else if (this.FONTDATA.REMAP[n] && !variant.noRemap) {
         n = this.FONTDATA.REMAP[n];
       }
-      if (n instanceof Array) {variant = VARIANT[n[1]]; n = n[0]} 
+      if (isArray(n)) {variant = VARIANT[n[1]]; n = n[0]} 
       if (typeof(n) === "string") {
         var string = {text:n, i:0, length:n.length};
         while (string.i < string.length) {

--- a/unpacked/jax/output/HTML-CSS/autoload/multiline.js
+++ b/unpacked/jax/output/HTML-CSS/autoload/multiline.js
@@ -686,7 +686,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
       //    use it to modify the default penalty
       //
       var linebreak = PENALTY[values.linebreak||MML.LINEBREAK.AUTO];
-      if (!(linebreak instanceof Array)) {
+      if (!MathJax.Object.isArray(linebreak)) {
         //  for breaks past the width, don't modify penalty
         if (offset >= 0) {penalty = linebreak * info.nest}
       } else {penalty = Math.max(1,penalty + linebreak[0] * info.nest)}
@@ -736,7 +736,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
       if (linebreakValue === MML.LINEBREAK.AUTO && w >= PENALTY.spacelimit &&
           !this.mathbackground && !this.background)
         {linebreak = [(w+PENALTY.spaceoffset)*PENALTY.spacefactor]}
-      if (!(linebreak instanceof Array)) {
+      if (!MathJax.Object.isArray(linebreak)) {
         //  for breaks past the width, don't modify penalty
         if (offset >= 0) {penalty = linebreak * info.nest}
       } else {penalty = Math.max(1,penalty + linebreak[0] * info.nest)}

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -28,6 +28,7 @@
 
 (function (AJAX,HUB,HTMLCSS) {
   var MML, isMobile = HUB.Browser.isMobile;
+  var isArray = MathJax.Object.isArray;
 
   var MESSAGE = function () {
     var data = [].slice.call(arguments,0);
@@ -416,7 +417,7 @@
       if (settings.scale) {config.scale = settings.scale}
       if (font && font !== "Auto" && this.fontName[font]) {
         config.availableFonts = []; delete config.fonts;
-        if (this.fontName[font] instanceof Array) {
+        if (isArray(this.fontName[font])) {
           config.preferredFont = this.fontName[font][0];
           config.webFont = this.fontName[font][1];
         } else {
@@ -1549,7 +1550,7 @@
         } else if (this.FONTDATA.REMAP[n] && !variant.noRemap) {
           n = this.FONTDATA.REMAP[n];
         }
-        if (n instanceof Array) {variant = this.FONTDATA.VARIANT[n[1]]; n = n[0]} 
+        if (isArray(n)) {variant = this.FONTDATA.VARIANT[n[1]]; n = n[0]} 
         if (typeof(n) === "string") {
           text = n+text.substr(i+1);
           m = text.length; i = -1;

--- a/unpacked/jax/output/SVG/autoload/multiline.js
+++ b/unpacked/jax/output/SVG/autoload/multiline.js
@@ -606,7 +606,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       //    use it to modify the default penalty
       //
       var linebreak = PENALTY[values.linebreak||MML.LINEBREAK.AUTO];
-      if (!(linebreak instanceof Array)) {
+      if (!MathJax.Object.isArray(linebreak)) {
         //  for breaks past the width, don't modify penalty
         if (offset >= 0) {penalty = linebreak * info.nest}
       } else {penalty = Math.max(1,penalty + linebreak[0] * info.nest)}
@@ -655,7 +655,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       if (linebreakValue === MML.LINEBREAK.AUTO && w >= PENALTY.spacelimit*1000 &&
           !this.mathbackground && !this.backrgound)
         {linebreak = [(w/1000+PENALTY.spaceoffset)*PENALTY.spacefactor]}
-      if (!(linebreak instanceof Array)) {
+      if (!MathJax.Object.isArray(linebreak)) {
         //  for breaks past the width, don't modify penalty
         if (offset >= 0) {penalty = linebreak * info.nest}
       } else {penalty = Math.max(1,penalty + linebreak[0] * info.nest)}

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -29,6 +29,7 @@
 
 (function (AJAX,HUB,HTML,SVG) {
   var MML;
+  var isArray = MathJax.Object.isArray;
 
   var SVGNS   = "http://www.w3.org/2000/svg";
   var XLINKNS = "http://www.w3.org/1999/xlink";
@@ -634,7 +635,7 @@
         } else if (this.FONTDATA.REMAP[n] && !variant.noRemap) {
           n = this.FONTDATA.REMAP[n];
         }
-        if (n instanceof Array) {variant = this.FONTDATA.VARIANT[n[1]]; n = n[0]}
+        if (isArray(n)) {variant = this.FONTDATA.VARIANT[n[1]]; n = n[0]}
         if (typeof(n) === "string") {
           text = n+text.substr(i+1);
           m = text.length; i = -1;


### PR DESCRIPTION
Add `MathJax.Object.isArray()` function, and change most `instanceof Array` to use it (unless the arrays are only going to generated by MathJax internals).  Also add `MathJax.Object.Array` for making arrays of the Array type used by MathJax.

Resolves issue #1584.