### PR TITLE
Move AssistiveMML and InTabOrder menus to new Accessibility submenu (…

### DIFF
--- a/unpacked/extensions/MathMenu.js
+++ b/unpacked/extensions/MathMenu.js
@@ -1555,9 +1555,7 @@
           ITEM.RADIO(["SVG","SVG"],                 "renderer", {action: MENU.Renderer}),
           ITEM.RADIO(["PlainSource","Plain Source"],"renderer", {action: MENU.Renderer, value:"PlainSource"}),
           ITEM.RULE(),
-          ITEM.CHECKBOX(["FastPreview","Fast Preview"], "FastPreview"),
-          ITEM.CHECKBOX(["AssistiveMML","Assistive MathML"], "assistiveMML", {action:MENU.AssistiveMML}),
-          ITEM.CHECKBOX(["InTabOrder","Include in Tab Order"], "inTabOrder")
+          ITEM.CHECKBOX(["FastPreview","Fast Preview"], "FastPreview")
         ),
         ITEM.SUBMENU("MathPlayer",  {hidden:!HUB.Browser.isMSIE || !CONFIG.showMathPlayer,
                                                     disabled:!HUB.Browser.hasMathPlayer},
@@ -1590,6 +1588,10 @@
         ITEM.COMMAND(["Scale","Scale All Math ..."],MENU.Scale),
         ITEM.RULE().With({hidden:!CONFIG.showDiscoverable, name:["","discover_rule"]}),
         ITEM.CHECKBOX(["Discoverable","Highlight on Hover"], "discoverable", {hidden:!CONFIG.showDiscoverable})
+      ),
+      ITEM.SUBMENU(["Accessibility","Accessibility"],
+        ITEM.CHECKBOX(["AssistiveMML","Assistive MathML"], "assistiveMML", {action:MENU.AssistiveMML}),
+        ITEM.CHECKBOX(["InTabOrder","Include in Tab Order"], "inTabOrder")
       ),
       ITEM.SUBMENU(["Locale","Language"],                  {hidden:!CONFIG.showLocale, ltr:true},
         ITEM.RADIO("en", "locale",  {action: MENU.Locale}),


### PR DESCRIPTION
Move AssistiveMML and InTabOrder menus to new Accessibility submenu (coordinates with mathjax/MathJax-a11y#153 to move accessibility menu items to the same location).

The a11y change should be pushed to the CDN before 2.7 is released.