### PR TITLE
Remove unwanted trailing comma.  #1670

### DIFF
--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -81,7 +81,7 @@
     ".mjx-math":   {
       "display":         "inline-block",
       "border-collapse": "separate",
-      "border-spacing":  0,
+      "border-spacing":  0
     },
     ".mjx-math *": {
       display:"inline-block",


### PR DESCRIPTION
Remove unwanted trailing comma.  This causes IE < 8 to complain.  Even though CommonHTML doesn't support IE < 8, it is good not to leave such commas lying around.

 Resolves issue #1670.