### PR TITLE
Work around WebKit handling of combining characters.  #1737

### DIFF
--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -2306,12 +2306,24 @@
           {if (this.data[i]) {this.data[i].toHTML(span,variant,this.remap,mapchars)}}
 	if (!span.bbox) {span.bbox = this.HTMLzeroBBox()}
 	if (text.length !== 1) {delete span.bbox.skew}
+
         //
-        //  Handle combining characters by adding a non-breaking space and removing that width
+        //  Handle combining character bugs
         //
-	if (HTMLCSS.AccentBug && span.bbox.w === 0 && text.length === 1 && span.firstChild) {
-	  span.firstChild.nodeValue += HTMLCSS.NBSP;
-	  HTMLCSS.createSpace(span,0,0,-span.offsetWidth/HTMLCSS.em);
+	if (span.bbox.w === 0 && text.length === 1 && span.firstChild) {
+          if (HTMLCSS.AccentBug) {
+            //
+            //  adding a non-breaking space and removing that width
+            //
+            span.firstChild.nodeValue += HTMLCSS.NBSP;
+            HTMLCSS.createSpace(span,0,0,-span.offsetWidth/HTMLCSS.em);
+          }
+          if (HTMLCSS.combiningCharBug) {
+            //
+            //  Safari turns these into non-combining characters
+            //
+            span.style.marginLeft = HTMLCSS.Em(span.bbox.lw);
+          }
 	}
         //
         //  Handle large operator centering
@@ -3175,6 +3187,7 @@
           safariTextNodeBug: !v3p0,
           forceReflow: true,
           FontFaceBug: true,
+          combiningCharBug: parseInt(browser.webkit) >= 603,
           allowWebFonts: (v3p1 && !forceImages ? "otf" : false)
         });
         if (trueSafari) {


### PR DESCRIPTION
Work around WebKit handling of combining characters in Safari 10.1.  Combining characters with nothing to combine with (as happens when they are used for accents in MathJax) are turned into non-combining characters by WebKit, and that means they are not positioned the same as in other browsers.  This affects `\vec` in particular.

Resolves issue #1737.