### PR TITLE
Handle FontFaceBug interaction with web fonts in Chrome.  #1774

### DIFF
--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -1586,8 +1586,9 @@
       var weight = (style.fontWeight||"normal");
       if (weight.match(/^\d+$/)) {weight = (parseInt(weight) >= 600 ? "bold" : "normal")}
       return (font.family.replace(/'/g,"") === style.fontFamily.replace(/'/g,"") &&
-             (font.style||"normal") === (style.fontStyle||"normal") &&
-             (font.weight||"normal") === weight);
+             (((font.style||"normal") === (style.fontStyle||"normal") &&
+             (font.weight||"normal") === weight) ||
+             (this.FontFaceBug && style.fontFamily !== '')));
     },
 
     handleFont: function (span,font,force) {


### PR DESCRIPTION
When web fonts are using in a browser that has `FontFaceBug` true in HTML-CSS output, then a MathML token element with `mathvariant` other than `normal` will produce extra spans for the second and subsequent letters in the content of the element.  E.g.,

    <mi mathvariant="italic">ab</mi>

will place the "b" in a separate span that is not needed.

Resolves issue #1774.