### PR TITLE
Add minimum height for accents.  #1706.

### DIFF
--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -2760,6 +2760,9 @@
 	      else if (HW != null) {this.data[this.base].HTMLstretchH(box,HW)}
 	      stretch[i] = (D == null && HW != null ? false :
 			   this.data[i].HTMLcanStretch("Horizontal"));
+              if (this.data[this.over] && values.accent) {
+                children[i].bbox.h = Math.max(children[i].bbox.h,HTMLCSS.TeX.x_height); // min height of 1ex (#1706)
+              }
 	    } else {
 	      stretch[i] = this.data[i].HTMLcanStretch("Horizontal");
               children[i].style.paddingLeft = children[i].style.paddingRight = "";

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -1947,7 +1947,10 @@
 	    if (i == this.base) {
               boxes[i] = this.SVGdataStretched(i,HW,D);
 	      stretch[i] = (D != null || HW == null) && this.data[i].SVGcanStretch("Horizontal");
-	    } else {
+              if (this.data[this.over] && values.accent) {
+                boxes[i].h = Math.max(boxes[i].h,SVG.TeX.x_height); // min height of 1ex (#1706)
+              }
+            } else {
               boxes[i] = this.data[i].toSVG(); boxes[i].x = 0; delete boxes[i].X;
 	      stretch[i] = this.data[i].SVGcanStretch("Horizontal");
 	    }


### PR DESCRIPTION
Add minimum height for bases of munderover when the over is an accent. This is for HTML-CSS and SVG.  CHTML currently already does this in accidentally in another way.

 Resolves issue #1706.