### PR TITLE
Better error messages for \shoveleft and \shoveright.  #1701

### DIFF
--- a/unpacked/extensions/TeX/AMSmath.js
+++ b/unpacked/extensions/TeX/AMSmath.js
@@ -245,7 +245,11 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
      */
     HandleShove: function (name,shove) {
       var top = this.stack.Top();
-      if (top.type !== "multline" || top.data.length) {
+      if (top.type !== "multline") {
+        TEX.Error(["CommandInMultline",
+                   "%1 can only appear within the multiline environment",name]);
+      }
+      if (top.data.length) {
         TEX.Error(["CommandAtTheBeginingOfLine",
                    "%1 must come at the beginning of the line",name]);
       }


### PR DESCRIPTION
Report better error when \shoveleft or \shoveright are used outside of multline environments.  

Resolves issue #1701.