### PR TITLE
Fix spacing aligned/alignedat.  #1690.

### DIFF
--- a/unpacked/extensions/TeX/AMSmath.js
+++ b/unpacked/extensions/TeX/AMSmath.js
@@ -549,7 +549,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
       stack.global.tagged = !numbered && !stack.global.forcetag; // prevent automatic tagging in starred environments
     },
     EndEntry: function () {
-      if (this.row.length) {this.fixInitialMO(this.data)}
+      if (this.row.length % 2 === 1) {this.fixInitialMO(this.data)}
       this.row.push(MML.mtd.apply(MML,this.data));
       this.data = [];
     },


### PR DESCRIPTION
The aligned/alignedat environment has to adjust spacing around equal signs and other relations (TeX spacing requires an operand on both sides to get the right spacing, so we add a blank one when needed).  This should only occur every other column, however.  This corrects the problem the MathJax was adding the empty elements on *every* column but the first one.

Resolves issue #1690.