### PR TITLE
Don't force width of large collections of text.  #1718.

### DIFF
--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -987,7 +987,7 @@
           if (bbox.a == null || state.a > bbox.a) bbox.a = state.a;
         }
         node = this.flushText(node,state,item.style);
-        node.style.width = CHTML.Em(C[2]);
+        if (C[2] < 3) node.style.width = CHTML.Em(C[2]); // only force width if not too large (#1718)
       },
       //
       //  Put the pending text into a box of the class, and


### PR DESCRIPTION
The inaccuracy of the measurement of the pixels-per-em has a larger effect for larger runs of text, so 
don't force width of large collections of text (in this case, over 3 ems).

Resolves issue #1718.