### PR TITLE
Fix CD problems cause by getNode().  #1691

### DIFF
--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -376,12 +376,16 @@
     //
     getNode: function (node,type) {
       var name = RegExp("\\b"+type+"\\b");
+      var nodes = [];
       while (node) {
         for (var i = 0, m = node.childNodes.length; i < m; i++) {
           var child = node.childNodes[i];
-          if (name.test(child.className)) return child;
+          if (child) {
+            if (name.test(child.className)) return child;
+            if ((child.id || "") === "") nodes.push(child);
+          }
         }
-        node = (node.firstChild && (node.firstChild.id||"") === "" ? node.firstChild : null);
+        node = nodes.shift();
       }
       return null;
     },

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -382,7 +382,7 @@
           var child = node.childNodes[i];
           if (child) {
             if (name.test(child.className)) return child;
-            if ((child.id || "") === "") nodes.push(child);
+            if (child.id === "") nodes.push(child);
           }
         }
         node = nodes.shift();


### PR DESCRIPTION
Some situations caused CD to produce Math Processing Errors (see #1691 for reduced test case).  This was caused by the `getNode()` method, which did not descend into all the children.  This PR fixes the problem by using a breadth-first search in `getNode()`, but stopping at nodes with `id`s, as these are other rendered MathML nodes (we only want to find nodes that are "direct" children of the current element, not similarly named ones inside nested elements).

Resolves #1691.