### PR TITLE
Fix problem with <=> arrow in mhchem.  1657

### DIFF
--- a/unpacked/extensions/TeX/mhchem3/mhchem.js
+++ b/unpacked/extensions/TeX/mhchem3/mhchem.js
@@ -1690,4 +1690,4 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
 
 });
 
-MathJax.Ajax.loadComplete("[mhchem]/unpacked/mhchem.js");
+MathJax.Ajax.loadComplete("[mhchem]/mhchem.js");

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -2156,8 +2156,8 @@
         //  Use a minimum height for accents (#1706)
         //  (same issues with the center line as above)
         //
-        if (values.accent && bbox.h < .431) {
-          base.style.marginTop = CHTML.Em(.431 - Math.max(bbox.h,.35));
+        if (values.accent && bbox.h < CHTML.TEX.x_height) {
+          base.style.marginTop = CHTML.Em(CHTML.TEX.x_height - Math.max(bbox.h,.35));
         }
         //
         //  Add over- and under-scripts

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -2146,6 +2146,20 @@
         var bbox = boxes[this.base], BBOX = this.CHTML;
         BBOX.w = W; BBOX.h = bbox.h; BBOX.d = bbox.d; // modified below
         //
+        // Adjust for bases shorter than the center line (#1657)
+        // (the center line really depends on the surrounding font, so
+        //  it should be measured along with ems and exs, but currently isn't.
+        //  so this value is an approximation that is reasonable for most fonts.)
+        //
+        if (bbox.h < .35) base.style.marginTop = CHTML.Em(bbox.h - .35);
+        //
+        //  Use a minimum height for accents (#1706)
+        //  (same issues with the center line as above)
+        //
+        if (values.accent && bbox.h < .431) {
+          base.style.marginTop = CHTML.Em(.431 - Math.max(bbox.h,.35));
+        }
+        //
         //  Add over- and under-scripts
         //  
         var stack = base, delta = 0;


### PR DESCRIPTION
This work around a problem with bounding boxes that are shorter than the center line of the text (the half way point between the font's ascent and descent).  Browsers pad boxes shorter than this to be this high, so CHTML has to compensate for that.

This is what was causing CHTML not to exhibit the minimum-height issue in #1706, so this PR would introduce that bug, and so we patch that here as well.

Resolves issue #1657.