### PR TITLE
Fix typo in function name

### DIFF
--- a/unpacked/latest.js
+++ b/unpacked/latest.js
@@ -129,7 +129,7 @@
            } else {
              Error("Problem aquiring MathJax version: status = " + request.status);
            }
-           laodDefaultMathJax();
+           loadDefaultMathJax();
          }
        }
        request.open('GET', cdn.api, true); 


### PR DESCRIPTION
Originally reported by ziktar in #1750, but this PR is from develop to develop, as required.