### PR TITLE
Fix positioning problem with accents.  #1798.

### DIFF
--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -1244,7 +1244,7 @@
       // Place the box
       var HH, dx = 0;
       if (span.HH != null) {HH = span.HH}
-        else if (bbox) {HH = Math.max(3,bbox.h+bbox.d)}
+        else if (bbox) {HH = Math.max(3,3*(span.firstChild.scale||1),bbox.h+bbox.d)}
         else {HH = span.offsetHeight/this.em}
       if (!span.noAdjust) {
         HH += 1;


### PR DESCRIPTION
Fix positioning problem with accents at large math sizes (due to the positioning strut not being large enough for the large size characters).  The fix is to use larger struts based on the scaling factor of the base characters.

Resolves issue #1798.