### PR TITLE
fix `HUB.Startup.signal.Post()` queued invocations: API expects STRING param, received ARRAY instead

### DIFF
--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -343,7 +343,7 @@
       if (!font.match(/-|fontdata/)) font += "-Regular";
       if (!font.match(/\.js$/)) font += ".js"
       MathJax.Callback.Queue(
-        ["Post",HUB.Startup.signal,["CommonHTML - font data loaded",font]],
+        ["Post",HUB.Startup.signal,"CommonHTML - font data loaded for " + font],
         ["loadComplete",AJAX,this.fontDir+"/"+font]
       );
     },

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -197,7 +197,7 @@
     },
     loadError: function (font) {
       MESSAGE(["CantLoadWebFont","Can't load web font %1",HTMLCSS.fontInUse+"/"+font.directory],null,2000);
-      HUB.Startup.signal.Post(["HTML-CSS Jax - web font error",HTMLCSS.fontInUse+"/"+font.directory,font]);
+      HUB.Startup.signal.Post("HTML-CSS Jax - web font error for " + HTMLCSS.fontInUse+"/"+font.directory);
     },
     firefoxFontError: function (font) {
       MESSAGE(["FirefoxCantLoadWebFont","Firefox can't load web fonts from a remote host"],null,3000);


### PR DESCRIPTION
This is a redo of #1878 -- trouble there was I _had_ prepped the patch against `develop` branch but had picked the `master` branch in the GitHub 'Open New PullReq' UI. 😞 

---

fix: `HUB.Startup.signal.Post()` API expects a single message STRING, so we must concatenate parts into a single string before queueing a call to this API. Fixes crash in `HUB.Startup.signal.Post()` itself where code expects a string type call parameter, rather than an array type parameter.