### PR TITLE
fix: typos in comments and a message string (English)

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -752,7 +752,7 @@ MathJax.Hub.Config({
     //
     //  When true, MathJax will not measure the widths or heights of the
     //  subexpressions as it creates its output, but instead will rely on
-    //  its internal calculautions based on teh bounding boxes of the
+    //  its internal calculations based on the bounding boxes of the
     //  characters it uses, and will only take measurements when it
     //  absolutely has to.  Since measurements cause display reflows, they
     //  slows down MathJax considerably, so without them MathJax runs

--- a/unpacked/config/default.js
+++ b/unpacked/config/default.js
@@ -752,7 +752,7 @@ MathJax.Hub.Config({
     //
     //  When true, MathJax will not measure the widths or heights of the
     //  subexpressions as it creates its output, but instead will rely on
-    //  its internal calculautions based on teh bounding boxes of the
+    //  its internal calculations based on the bounding boxes of the
     //  characters it uses, and will only take measurements when it
     //  absolutely has to.  Since measurements cause display reflows, they
     //  slows down MathJax considerably, so without them MathJax runs

--- a/unpacked/extensions/HelpDialog.js
+++ b/unpacked/extensions/HelpDialog.js
@@ -196,7 +196,7 @@
   MathJax.Callback.Queue(
     HUB.Register.StartupHook("End Config",{}), // wait until config is complete
     ["Styles",AJAX,CONFIG.styles],
-    ["Post",HUB.Startup.signal,"HelpDialig Ready"],
+    ["Post",HUB.Startup.signal,"HelpDialog Ready"],
     ["loadComplete",AJAX,"[MathJax]/extensions/HelpDialog.js"]
   );
 


### PR DESCRIPTION
redo of #1877, which went wrong due to same mistake as mentioned in #1889.