### PR TITLE
Fix position of rightmost glyph in horizontal stretchy characters in HTML-CSS.  #1896

### DIFF
--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -1457,6 +1457,7 @@
         if (delim.mid) {this.placeBox(mid,x,0,true); x += mid.bbox.w};
         x -= (w - W)/2;
       }
+      x -= right.bbox.lw;
       this.placeBox(right,x,0,true);
       span.bbox = {
         w: x+right.bbox.rw, lw: 0, rw: x+right.bbox.rw,


### PR DESCRIPTION
Fix position of rightmost glyph in horizontal stretchy characters in HTML-CSS.  It turns out that the left-bearing of the right-moist glyph wasn't being taken into account for the placement of the character.

Resolves issue #1896