### PR TITLE
Properly scale widths in SVG line breaking algorithm.  #1881

### DIFF
--- a/unpacked/jax/output/CommonHTML/autoload/multiline.js
+++ b/unpacked/jax/output/CommonHTML/autoload/multiline.js
@@ -172,7 +172,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
     CHTMLaddWidth: function (i,info,scanW) {
       if (this.data[i]) {
         var bbox = this.data[i].CHTML;
-        scanW += bbox.w + (bbox.L||0) + (bbox.R||0);
+        scanW += (bbox.w + (bbox.L||0) + (bbox.R||0)) * (bbox.rscale || 1);
         info.W = info.scanW = scanW; info.w = 0;
       }
       return scanW;


### PR DESCRIPTION
Properly scale element widths when looking for linebreaks in SVG output.  Resolves #1881.