### PR TITLE
Measure sizes of annotation-xml properly in SVG.  #1870.

### DIFF
--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -87,6 +87,10 @@
           "-o-transition": "none"
         },
         
+        ".MathJax_SVG > div": {
+          display: "inline-block"
+        },
+        
         ".mjx-svg-href": {
           fill: "blue", stroke: "blue"
         },


### PR DESCRIPTION
Measure sizes of annotation-xml properly in SVG by using `display: inline-block` rather than just `block` for the container that is being measured.

Resolves issue #1870.