### PR TITLE
Make \DeclareMathOperator and \Newextarrow localizable by begingroup.  #1876

### DIFF
--- a/unpacked/extensions/TeX/AMSmath.js
+++ b/unpacked/extensions/TeX/AMSmath.js
@@ -224,7 +224,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
       if (cs.charAt(0) == "\\") {cs = cs.substr(1)}
       var op = this.GetArgument(name);
       op = op.replace(/\*/g,'\\text{*}').replace(/-/g,'\\text{-}');
-      TEX.Definitions.macros[cs] = ['Macro','\\mathop{\\rm '+op+'}'+limits];
+      this.setDef(cs, ['Macro', '\\mathop{\\rm '+op+'}'+limits]);
     },
     
     HandleOperatorName: function (name) {

--- a/unpacked/extensions/TeX/begingroup.js
+++ b/unpacked/extensions/TeX/begingroup.js
@@ -193,9 +193,9 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
     macros: {
       begingroup: "BeginGroup",
       endgroup:   "EndGroup",
-      global:     ["Extension","newcommand"],
-      gdef:       ["Extension","newcommand"]
-    }
+      global:     "Global",
+      gdef:      ["Macro","\\global\\def"]
+     }
   },null,true);
   
   TEX.Parse.Augment({
@@ -232,8 +232,34 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
     },
     envFindName: function (name) {
       return (TEX.eqnStack.Find(name,"environments") || TEX.rootStack.Find(name,"environments"));
-    }
+    },
 
+    //
+    //  Modify the way macros and environments are defined
+    //  to make them go into the equation namespace stack
+    //
+    setDef: function (name,value) {
+      value.isUser = true;
+      TEX.eqnStack.Def(name,value,"macros",this.stack.env.isGlobal);
+      delete this.stack.env.isGlobal;
+    },
+    setEnv: function (name,value) {
+      value.isUser = true;
+      TEX.eqnStack.Def(name,value,"environments")
+    },
+
+    //
+    //  Implement \global (for \global\let, \global\def and \global\newcommand)
+    //
+    Global: function (name) {
+      var i = this.i; var cs = this.GetCSname(name); this.i = i;
+      if (cs !== "let" && cs !== "def" && cs !== "newcommand" &&
+          cs !== "DeclareMathOperator" && cs !== "Newextarrow") {
+        TEX.Error(["GlobalNotFollowedBy",
+                   "%1 not followed by \\let, \\def, or \\newcommand",name]);
+      }
+      this.stack.env.isGlobal = true;
+    }
   });
 
   /****************************************************/
@@ -258,49 +284,6 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
   TEX.postfilterHooks.Add(function () {TEX.rootStack.Merge(TEX.eqnStack)});
   
   /*********************************************************/
-
-  MathJax.Hub.Register.StartupHook("TeX newcommand Ready",function () {
-
-    //
-    //  Add the commands that depend on the newcommand code
-    //
-    TEXDEF.Add({
-      macros: {
-        global: "Global",
-        gdef:   ["Macro","\\global\\def"]
-      }
-    },null,true);
-
-    TEX.Parse.Augment({
-      //
-      //  Modify the way macros and environments are defined
-      //  to make them go into the equation namespace stack
-      //
-      setDef: function (name,value) {
-        value.isUser = true;
-        TEX.eqnStack.Def(name,value,"macros",this.stack.env.isGlobal);
-        delete this.stack.env.isGlobal;
-      },
-      setEnv: function (name,value) {
-        value.isUser = true;
-        TEX.eqnStack.Def(name,value,"environments")
-      },
-
-      //
-      //  Implement \global (for \global\let, \global\def and \global\newcommand)
-      //
-      Global: function (name) {
-        var i = this.i; var cs = this.GetCSname(name); this.i = i;
-        if (cs !== "let" && cs !== "def" && cs !== "newcommand") {
-          TEX.Error(["GlobalNotFollowedBy",
-                     "%1 not followed by \\let, \\def, or \\newcommand",name]);
-        }
-        this.stack.env.isGlobal = true;
-      }
-
-    });
-
-  });
 
   MathJax.Hub.Startup.signal.Post("TeX begingroup Ready");
 

--- a/unpacked/extensions/TeX/extpfeil.js
+++ b/unpacked/extensions/TeX/extpfeil.js
@@ -92,7 +92,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
         );
       }
       cs = cs.substr(1); space = space.split(","); chr = parseInt(chr);
-      TEXDEF.macros[cs] = ['xArrow',chr,parseInt(space[0]),parseInt(space[1])];
+      this.setDef(cs, ['xArrow', chr, parseInt(space[0]), parseInt(space[1])]);
     }
   });
   

--- a/unpacked/extensions/TeX/newcommand.js
+++ b/unpacked/extensions/TeX/newcommand.js
@@ -131,13 +131,6 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
     },
     
     /*
-     *  Routines to set the macro and environment definitions
-     *  (overridden by begingroup to make localized versions)
-     */
-    setDef: function (name,value) {value.isUser = true; TEXDEF.macros[name] = value},
-    setEnv: function (name,value) {value.isUser = true; TEXDEF.environment[name] = value},
-    
-    /*
      *  Get a CS name or give an error
      */
     GetCSname: function (cmd) {

--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -2159,6 +2159,13 @@
     },
 
     /*
+     *  Routines to set the macro and environment definitions
+     *  (overridden by begingroup to make localized versions)
+     */
+    setDef: function (name,value) {value.isUser = true; TEXDEF.macros[name] = value},
+    setEnv: function (name,value) {value.isUser = true; TEXDEF.environment[name] = value},
+    
+    /*
      *  Replace macro parameters with their values
      */
     SubstituteArgs: function (args,string) {


### PR DESCRIPTION
Move `setDef()` and `setEnv()` to TeX jax, and use them for `\DeclareMathOperator` and `\Newextarrow` so they can be localized via the begingroup extension.  Also, no need to wait for newcommand any longer, since `setDef()` and `setEnv()` are predefined now.

Resolves issue #1876