### PR TITLE
Make \tag handling more robust.  #1899

### DIFF
--- a/unpacked/jax/input/TeX/config.js
+++ b/unpacked/jax/input/TeX/config.js
@@ -41,8 +41,8 @@ MathJax.InputJax.TeX = MathJax.InputJax({
                            //  or "all" for all displayed equations
       formatNumber: function (n) {return n},
       formatTag:    function (n) {return '('+n+')'},
-      formatID:     function (n) {return 'mjx-eqn-'+String(n).replace(/[:"'<>&]/g,"")},
-      formatURL:    function (id,base) {return base+'#'+escape(id)},
+      formatID:     function (n) {return 'mjx-eqn-'+String(n).replace(/\s/g,"_")},
+      formatURL:    function (id,base) {return base+'#'+escapeURIComponent(id)},
       useLabelIds:  true
     }
   },


### PR DESCRIPTION
Remove spaces from tag IDs, but allow other characters (since they are legal in HTML5) and use encodeURIComponent() rather than encode().  People who want to filter more characters can override this funciton in their own configurations.

Resolves issue #1899.