### PR TITLE
Properly handle pre-spacing for elements with linebreaks in SVG outpu…

### DIFF
--- a/unpacked/jax/output/SVG/autoload/multiline.js
+++ b/unpacked/jax/output/SVG/autoload/multiline.js
@@ -310,6 +310,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       slice.Clean();
       if (this.href) {this.SVGaddHref(slice)}
       this.SVGhandleColor(slice);
+      if (start.length == 0) this.SVGhandleSpace(slice);
       svg.Add(slice,svg.w,0,true);
       return slice;
     },


### PR DESCRIPTION
Properly handle pre-spacing for elements with linebreaks in SVG output.  (The *x*-offset from `SVGhandleSpace()` was being lost when the new container element is created.)

Resolves issue #1866.