### PR TITLE
Improve line breaks past the container width.  #1883.

### DIFF
--- a/unpacked/jax/output/CommonHTML/autoload/multiline.js
+++ b/unpacked/jax/output/CommonHTML/autoload/multiline.js
@@ -40,6 +40,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
     badbreak:    [+200],
     auto:           [0],
     
+    maxwidth:     1.33,  // stop looking for breaks after this time the line-break width
     toobig:        800,
     nestfactor:    400,
     spacefactor:  -100,
@@ -150,7 +151,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       //  Look through the line for breakpoints,
       //    (as long as we are not too far past the breaking width)
       //
-      while (i < m && info.scanW < 1.33*CHTML.linebreakWidth) {
+      while (i < m && (info.scanW < PENALTY.maxwidth*CHTML.linebreakWidth || info.w === 0)) {
         if (this.data[i]) {
           if (this.data[i].CHTMLbetterBreak(info,state)) {
             better = true; index = [i].concat(info.index); W = info.W; w = info.w;
@@ -400,7 +401,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       //  Look through the line for breakpoints, including the open, close, and separators
       //    (as long as we are not too far past the breaking width)
       //
-      while (i < m && info.scanW < 1.33*CHTML.linebreakWidth) {
+      while (i < m && (info.scanW < PENALTY.maxwidth*CHTML.linebreakWidth || info.w === 0)) {
         var k = this.dataI[i];
         if (this.data[k]) {
           if (this.data[k].CHTMLbetterBreak(info,state)) {

--- a/unpacked/jax/output/HTML-CSS/autoload/multiline.js
+++ b/unpacked/jax/output/HTML-CSS/autoload/multiline.js
@@ -39,6 +39,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
     badbreak:    [+200],
     auto:           [0],
     
+    maxwidth:     1.33,  // stop looking for breaks after this time the line-break width
     toobig:        800,
     nestfactor:    400,
     spacefactor:  -100,
@@ -157,7 +158,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
       //  Look through the line for breakpoints,
       //    (as long as we are not too far past the breaking width)
       //
-      while (i < m && info.scanW < 1.33*HTMLCSS.linebreakWidth) {
+      while (i < m && (info.scanW < PENALTY.maxwidth*HTMLCSS.linebreakWidth || info.w === 0)) {
         if (this.data[i]) {
           if (this.data[i].HTMLbetterBreak(info,state)) {
             better = true; index = [i].concat(info.index); W = info.W; w = info.w;
@@ -411,7 +412,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
       //  Look through the line for breakpoints, including the open, close, and separators
       //    (as long as we are not too far past the breaking width)
       //
-      while (i < m && info.scanW < 1.33*HTMLCSS.linebreakWidth) {
+      while (i < m && (info.scanW < PENALTY.maxwidth*HTMLCSS.linebreakWidth || info.w === 0)) {
         var k = this.dataI[i];
         if (this.data[k]) {
           if (this.data[k].HTMLbetterBreak(info,state)) {

--- a/unpacked/jax/output/SVG/autoload/multiline.js
+++ b/unpacked/jax/output/SVG/autoload/multiline.js
@@ -40,6 +40,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
     badbreak:    [+200],
     auto:           [0],
     
+    maxwidth:     1.33,  // stop looking for breaks after this time the line-break width
     toobig:        800,
     nestfactor:    400,
     spacefactor:  -100,
@@ -162,7 +163,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       //  Look through the line for breakpoints,
       //    (as long as we are not too far past the breaking width)
       //
-      while (i < m && info.scanW < 1.33*SVG.linebreakWidth) {
+      while (i < m && (info.scanW < PENALTY.maxwidth*SVG.linebreakWidth || info.w === 0)) {
         if (this.data[i]) {
           if (this.data[i].SVGbetterBreak(info,state)) {
             better = true; index = [i].concat(info.index); W = info.W; w = info.w;
@@ -369,7 +370,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       //  Look through the line for breakpoints, including the open, close, and separators
       //    (as long as we are not too far past the breaking width)
       //
-      while (i < m && info.scanW < 1.33*SVG.linebreakWidth) {
+      while (i < m && (info.scanW < PENALTY.maxwidth*SVG.linebreakWidth || info.w === 0)) {
         var k = this.dataI[i];
         if (this.data[k]) {
           if (this.data[k].SVGbetterBreak(info,state)) {


### PR DESCRIPTION
Make maximum linebreak width a parameter in all three output formats, and only stop if a linebreak has been found.

Resolves issue #1883.