### PR TITLE
Recreate MathJax.Message.text if needed.  #1920.

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -1694,6 +1694,8 @@ MathJax.Message = {
         this.MoveFrame();
       }
       this.div = this.addDiv(frame); this.div.style.display = "none";
+    }
+    if (!this.text) {
       this.text = this.div.appendChild(document.createTextNode(""));
     }
     return true;


### PR DESCRIPTION
Recreate `MathJax.Message.text` if it has been lost due to changes in `document.body.innerHTML`.

Resolves issue #1920.