### PR TITLE
Make monospaced non-breaking space be of correct width.  #1953

### DIFF
--- a/unpacked/jax/output/CommonHTML/fonts/TeX/fontdata.js
+++ b/unpacked/jax/output/CommonHTML/fonts/TeX/fontdata.js
@@ -1640,6 +1640,8 @@
   MathJax.Hub.Register.LoadHook(CHTML.fontDir+"/TeX/Typewriter-Regular.js",function () {
     CHTML.FONTDATA.FONTS['MathJax_Typewriter'][0x20][2] += 275;       // fix error in character width
     CHTML.FONTDATA.FONTS['MathJax_Typewriter'][0x20][5] = {rfix:275}; // fix error in character width
+    CHTML.FONTDATA.FONTS['MathJax_Typewriter'][0xA0][2] += 275;       // fix error in character width
+    CHTML.FONTDATA.FONTS['MathJax_Typewriter'][0xA0][5] = {rfix:275}; // fix error in character width
   });
   
   //

--- a/unpacked/jax/output/HTML-CSS/fonts/STIX/fontdata.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX/fontdata.js
@@ -94,7 +94,7 @@
         "sans-serif-italic": {fonts: [ITALIC,NONUNII], offsetA: 0x1D608, offsetN: 0xE1B4, offsetG: 0xE1BF, offsetE: 0xE1BF, italic:true},
         "sans-serif-bold-italic": {fonts: [BITALIC,"STIXNonUnicode-bold-italic"], offsetA: 0x1D63C, offsetN: 0xE1F6, offsetG: 0x1D790, bold:true, italic:true},
         "monospace": {offsetA: 0x1D670, offsetN: 0x1D7F6,
-                   remap: {0x20: [0x20,"-STIX-variant"]}}, // use a special space for monospace (see below)
+                   remap: {0x20: [0x20,"-STIX-variant"], 0xA0: [0xA0,"-STIX-variant"]}}, // use a special space for monospace (see below)
         "-STIX-variant": {fonts:["STIXVariants",NONUNI,GENERAL],
                    remap: {0x2A87: 0xE010, 0x2A88: 0xE00F, 0x2270: 0xE011, 0x2271: 0xE00E,
                            0x22E0: 0xE04B, 0x22E1: 0xE04F, 0x2288: 0xE016, 0x2289: 0xE018,
@@ -1526,6 +1526,8 @@
     // monospace mathvariant uses space from STIXVariants, so make it the right size
     HTMLCSS.FONTDATA.FONTS['STIXVariants'][0x20][2] += 275;       // fix error in character width
     HTMLCSS.FONTDATA.FONTS['STIXVariants'][0x20][5] = {rfix:275}; // fix error in character width
+    HTMLCSS.FONTDATA.FONTS['STIXVariants'][0xA0][2] += 275;       // fix error in character width
+    HTMLCSS.FONTDATA.FONTS['STIXVariants'][0xA0][5] = {rfix:275}; // fix error in character width
   });
 
   //

--- a/unpacked/jax/output/HTML-CSS/fonts/TeX/fontdata.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/TeX/fontdata.js
@@ -1588,6 +1588,10 @@
     HTMLCSS.FONTDATA.FONTS['MathJax_Typewriter'][0x20][2] += 275;       // fix error in character width
     HTMLCSS.FONTDATA.FONTS['MathJax_Typewriter'][0x20][5] = {rfix:275}; // fix error in character width
   });
+  MathJax.Hub.Register.LoadHook(HTMLCSS.fontDir+"/Typewriter/Regular/Other.js",function () {
+    HTMLCSS.FONTDATA.FONTS['MathJax_Typewriter'][0xA0][2] += 275;       // fix error in character width
+    HTMLCSS.FONTDATA.FONTS['MathJax_Typewriter'][0xA0][5] = {rfix:275}; // fix error in character width
+  });
   
   //
   //  Add some spacing characters (more will come later)


### PR DESCRIPTION
This adds fixes for the monospaced non-breaking space similar to the ones for the standard space.  This affects the HTML-CSS and CommonHTML TeX fonts, and the HTML-CSS local STIX font (since it doesn't have a monospaced font, it uses the math alphabet characters along with the standard space and non-breaking space, but these are the wrong size).

Resolves issue #1953.