### PR TITLE
CSS reset for box-sizing.  #1942

### DIFF
--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -305,7 +305,8 @@
 	  display: "inline", position: "static",
 	  border: 0, padding: 0, margin: 0,
 	  "vertical-align": 0, "line-height": "normal",
-	  "text-decoration": "none"
+	  "text-decoration": "none",
+          "box-sizing": "content-box"
 	},
 
         ".MathJax nobr": {


### PR DESCRIPTION
CSS reset for `box-sizing` in HTML-CSS output.

Resolves issue #1942.