### PR TITLE
Always set movablelimits to false in overset and underset.  #1929

### DIFF
--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -1464,12 +1464,12 @@
     
     Overset: function (name) {
       var top = this.ParseArg(name), base = this.ParseArg(name);
-      if (base.movablelimits) base.movablelimits = false;
+      base.movablelimits = false;
       this.Push(MML.mover(base,top));
     },
     Underset: function (name) {
       var bot = this.ParseArg(name), base = this.ParseArg(name);
-      if (base.movablelimits) base.movablelimits = false;
+      base.movablelimits = false;
       this.Push(MML.munder(base,bot));
     },
     


### PR DESCRIPTION
Always set `movablelimits` to `false` on the base in `\overset` and `\underset` (rather than trying to do it only when needed, which doesn't take the operator table defaults into account.)

 Resolves issue #1929.