### PR TITLE
Prevent infinite loop if an autoloaded component fails to load.  #1936

### DIFF
--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -1759,10 +1759,19 @@
       //  Autoload files based on node type or file name
       //
       CHTMLautoload: function () {
+        this.toCommonHTML = MML.mbase.CHTMLautoloadFail;
 	var file = CHTML.autoloadDir+"/"+this.type+".js";
 	HUB.RestartAfter(AJAX.Require(file));
       },
+      CHTMLautoloadFail: function () {
+        throw Error("CommonHTML can't autoload '"+ this.type + "'");
+      },
+      CHTMLautoloadList: {},
       CHTMLautoloadFile: function (name) {
+        if (MML.mbase.CHTMLautoloadList.hasOwnProperty(name)) {
+          throw Error("CommonHTML can't autoload file '"+name+"'");
+        }
+        MML.mbase.CHTMLautoloadList[name] = true;
 	var file = CHTML.autoloadDir+"/"+name+".js";
 	HUB.RestartAfter(AJAX.Require(file));
       },

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -2192,10 +2192,19 @@
 
     },{
       HTMLautoload: function () {
+        this.toHTML = MML.mbase.HTMLautoloadFail;
 	var file = HTMLCSS.autoloadDir+"/"+this.type+".js";
 	HUB.RestartAfter(AJAX.Require(file));
       },
+      HTMLautoloadFail: function () {
+        throw Error("HTML-CSS can't autoload '"+ this.type + "'");
+      },
+      HTMLautoloadList: {},
       HTMLautoloadFile: function (name) {
+        if (MML.mbase.HTMLautoloadList.hasOwnProperty(name)) {
+          throw Error("HTML-CSS can't autoload file '"+name+"'");
+        }
+        MML.mbase.HTMLautoloadList[name] = true;
 	var file = HTMLCSS.autoloadDir+"/"+name+".js";
 	HUB.RestartAfter(AJAX.Require(file));
       },

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -1453,10 +1453,19 @@
 	return svg;
       },
       SVGautoload: function () {
+        this.toSVG = MML.mbase.SVGautoloadFail;
 	var file = SVG.autoloadDir+"/"+this.type+".js";
 	HUB.RestartAfter(AJAX.Require(file));
       },
+      SVGautoloadFail: function () {
+        throw Error("SVG can't autoload '"+ this.type + "'");
+      },
+      SVGautoloadList: {},
       SVGautoloadFile: function (name) {
+        if (MML.mbase.SVGautoloadList.hasOwnProperty(name)) {
+          throw Error("SVG can't autoload file '"+name+"'");
+        }
+        MML.mbase.SVGautoloadList[name] = true;
 	var file = SVG.autoloadDir+"/"+name+".js";
 	HUB.RestartAfter(AJAX.Require(file));
       }


### PR DESCRIPTION
Prevent infinite loop if an autoloaded component fails to load in HTML-CSS, CommonHTML, and SVG output.  

Resolves issue #1936