### PR TITLE
Fix problems with multline in CHTML (with tags) and SVG (with small containers).  #1974

### DIFF
--- a/unpacked/jax/output/CommonHTML/autoload/mtable.js
+++ b/unpacked/jax/output/CommonHTML/autoload/mtable.js
@@ -409,8 +409,10 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       //  Set variable width on DOM nodes
       //
       if (relWidth) {
-        this.CHTML.pwidth = values.width; this.CHTML.mwidth = CHTML.Em(TW);
-        node.style.width = node.firstChild.style.width = "100%";
+        node.style.width = this.CHTML.pwidth = "100%";
+        this.CHTML.mwidth = CHTML.Em(TW);
+        node.firstChild.style.width = values.width;
+        node.firstChild.style.margin = "auto";
       }
     },
     //

--- a/unpacked/jax/output/SVG/autoload/mtable.js
+++ b/unpacked/jax/output/SVG/autoload/mtable.js
@@ -226,7 +226,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
         if (values.width === "auto") {
           if (WP > .98) {Wf = Wp/(Wt+Wp); WW = Wt + Wp} else {WW = Wt / (1-WP)}
         } else {
-          WW = SVG.length2em(values.width,mu);
+          WW = Math.max(Wt + Wp, SVG.length2em(values.width,mu));
           for (i = 0, m = Math.min(J,CSPACE.length); i < m; i++) {WW -= CSPACE[i]}
         }
         //  Determine the relative column widths


### PR DESCRIPTION
Fix CHTML width problem with multline with tags, and SVG multline with small container widths.  

Resolves issue #1974.