### PR TITLE
Add CSS for munder.  #1981

### DIFF
--- a/unpacked/jax/output/PreviewHTML/jax.js
+++ b/unpacked/jax/output/PreviewHTML/jax.js
@@ -89,10 +89,10 @@
 
     ".MJXp-mphantom": {"visibility": "hidden"},
 
-    ".MJXp-munderover": {"display":"inline-table!important"},
+    ".MJXp-munderover, .MJXp-munder": {"display":"inline-table!important"},
     ".MJXp-over": {"display":"inline-block!important","text-align":"center"},
     ".MJXp-over > *": {"display":"block!important"},
-    ".MJXp-munderover > *": {"display":"table-row!important"},
+    ".MJXp-munderover > *, .MJXp-munder > *": {"display":"table-row!important"},
 
     ".MJXp-mtable": {"vertical-align":".25em", "margin":"0 .125em"},
     ".MJXp-mtable > *": {"display":"inline-table!important", "vertical-align":"middle"},


### PR DESCRIPTION
This adds missing CSS for `munder` that mirrors that of `munderover`.

Resolves issue #1981