### PR TITLE
Don't rescale mstyle bbox for scriptstyle changes.  #1985

### DIFF
--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -2742,16 +2742,6 @@
 
     /********************************************************/
     
-    MML.mstyle.Augment({
-      toCommonHTML: function (node) {
-        node = this.CHTMLdefaultNode(node);
-        if (this.scriptlevel && this.data[0]) this.CHTML.rescale(this.data[0].CHTML.rscale);
-        return node;
-      }
-    });
-
-    /********************************************************/
-    
     MML.TeXAtom.Augment({
       toCommonHTML: function (node,options) {
         if (!options || !options.stretch) node = this.CHTMLdefaultNode(node);


### PR DESCRIPTION
Don't rescale `mstyle` bbox for `scriptstyle` changes (that is handled automatically).  The only reason to augment the `mstyle` element in CHTML was for that rescaling, so the whole `toCommonHTML()` method is removed.

Resolves issue #1985.