### PR TITLE
Avoid line breaks for inline math in in WebKit. #1982

### DIFF
--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -189,8 +189,11 @@
       clear:   "both"
     },
     ".mjx-ex-box": {
+      display: "inline-block!important",
       position: "absolute",
       overflow: "hidden",
+      "min-height": 0, "max-height":"none",
+      padding:0, border: 0, margin: 0,
       width:"1px", height:"60ex"
     },
     ".mjx-test-inline .mjx-left-box": {
@@ -303,7 +306,7 @@
       test.className += " mjx-test-inline mjx-test-default";
       this.defaultEm    = this.getFontSize(test);
       this.defaultEx    = test.childNodes[1].offsetHeight/60;
-      this.defaultWidth = test.lastChild.offsetLeft - test.firstChild.offsetLeft;
+      this.defaultWidth = Math.max(0,test.lastChild.offsetLeft-test.firstChild.offsetLeft-2);
       document.body.removeChild(test);
     },
     getFontSize: (window.getComputedStyle ? 
@@ -485,6 +488,7 @@
           ex = this.defaultEx;
           cwidth = this.defaultWidth;
         }
+        if (cwidth === 0) cwidth = this.defaultWidth;
         if (relwidth) maxwidth = cwidth;
         scale = (this.config.matchFontHeight ? ex/this.TEX.x_height/em : 1);
         scale = Math.floor(Math.max(this.config.minScaleAdjust/100,scale)*this.config.scale);

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -273,7 +273,8 @@
       //
       // Used in preTranslate to get scaling factors and line width
       //
-      this.TestSpan = CHTML.Element("mjx-test",{},[["mjx-left-box"],["mjx-ex-box"],["mjx-right-box"]]);
+      this.TestSpan = CHTML.Element("mjx-test",{style:{left:"1em"}},
+          [["mjx-left-box"],["mjx-ex-box"],["mjx-right-box"]]);
 
       //
       //  Set up styles and preload web fonts

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -182,10 +182,10 @@
     },
     ".mjx-test.mjx-test-inline": {
       display:           "inline!important",
-      "margin-right":    "-1px",
+      "margin-right":    "-1px"
     },
     ".mjx-test.mjx-test-default": {
-      display: "block",
+      display: "block!important",
       clear:   "both"
     },
     ".mjx-ex-box": {

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -166,7 +166,6 @@
     ".MJXc-processed": {display:"none"},
     
     ".mjx-test": {
-      display:           "block",
       "font-style":      "normal",
       "font-weight":     "normal",
       "font-size":       "100%",
@@ -178,13 +177,33 @@
       overflow:          "hidden",
       height:            "1px"
     },
-    ".mjx-ex-box-test": {
+    ".mjx-test.mjx-test-display": {
+      display: "table!important"
+    },
+    ".mjx-test.mjx-test-inline": {
+      display:           "inline!important",
+      "margin-right":    "-1px",
+    },
+    ".mjx-test.mjx-test-default": {
+      display: "block",
+      clear:   "both"
+    },
+    ".mjx-ex-box": {
       position: "absolute",
       overflow: "hidden",
       width:"1px", height:"60ex"
     },
-    ".mjx-line-box-test": {display: "table!important"},
-    ".mjx-line-box-test span": {
+    ".mjx-test-inline .mjx-left-box": {
+      display: "inline-block",
+      width: 0,
+      float:"left"
+    },
+    ".mjx-test-inline .mjx-right-box": {
+      display: "inline-block",
+      width: 0,
+      float:"right"
+    },
+    ".mjx-test-display .mjx-right-box": {
       display: "table-cell!important",
       width: "10000em!important",
       "min-width":0, "max-width":"none",
@@ -251,12 +270,7 @@
       //
       // Used in preTranslate to get scaling factors and line width
       //
-      this.TestSpan = CHTML.Element("mjx-test",{style:{left:"1em"}},[["mjx-ex-box-test"]]);
-
-      //
-      // Used in preTranslate to get linebreak width
-      //
-      this.linebreakSpan = HTML.Element("span",{className:"mjx-line-box-test"},[["span"]]);
+      this.TestSpan = CHTML.Element("mjx-test",{},[["mjx-left-box"],["mjx-ex-box"],["mjx-right-box"]]);
 
       //
       //  Set up styles and preload web fonts
@@ -285,13 +299,12 @@
       //
       //  Get the default sizes (need styles in place to do this)
       //
-      document.body.appendChild(this.TestSpan);
-      document.body.appendChild(this.linebreakSpan);
-      this.defaultEm    = this.getFontSize(this.TestSpan);
-      this.defaultEx    = this.TestSpan.firstChild.offsetHeight/60;
-      this.defaultWidth = this.linebreakSpan.firstChild.offsetWidth;
-      document.body.removeChild(this.linebreakSpan);
-      document.body.removeChild(this.TestSpan);
+      var test = document.body.appendChild(this.TestSpan.cloneNode(true));
+      test.className += " mjx-test-inline mjx-test-default";
+      this.defaultEm    = this.getFontSize(test);
+      this.defaultEx    = test.childNodes[1].offsetHeight/60;
+      this.defaultWidth = test.lastChild.offsetLeft - test.firstChild.offsetLeft;
+      document.body.removeChild(test);
     },
     getFontSize: (window.getComputedStyle ? 
       function (node) {
@@ -395,7 +408,7 @@
     
     preTranslate: function (state) {
       var scripts = state.jax[this.id], i, m = scripts.length,
-          script, prev, node, test, span, jax, ex, em, scale;
+          script, prev, node, test, jax, ex, em, scale;
       //
       //  Get linebreaking information
       //
@@ -450,10 +463,11 @@
         node.className += " MJXc-processing";
         script.parentNode.insertBefore(node,script);
         //
-        //  Add test nodes for determineing scales and linebreak widths
+        //  Add test nodes for determining scales and linebreak widths
         //
-        script.parentNode.insertBefore(this.linebreakSpan.cloneNode(true),script);
-        script.parentNode.insertBefore(this.TestSpan.cloneNode(true),script);
+        test = this.TestSpan.cloneNode(true);
+        test.className += " mjx-test-" + (jax.CHTML.display ? "display" : "inline");
+        script.parentNode.insertBefore(test,script);
       }
       //
       //  Determine the scaling factors for each script
@@ -464,8 +478,9 @@
         test = script.previousSibling;
         jax = script.MathJax.elementJax; if (!jax) continue;
         em = CHTML.getFontSize(test);
-        ex = test.firstChild.offsetHeight/60;
-        cwidth = Math.max(0,test.previousSibling.firstChild.offsetWidth-2);
+        ex = test.childNodes[1].offsetHeight/60;
+        cwidth = Math.max(0, jax.CHTML.display ? test.lastChild.offsetWidth - 1: 
+                  test.lastChild.offsetLeft - test.firstChild.offsetLeft - 2);
         if (ex === 0 || ex === "NaN") {
           ex = this.defaultEx;
           cwidth = this.defaultWidth;
@@ -483,11 +498,8 @@
       //
       for (i = 0; i < m; i++) {
         script = scripts[i]; if (!script.parentNode) continue;
-        test = script.previousSibling;
-        span = test.previousSibling;
         jax = script.MathJax.elementJax; if (!jax) continue;
-        span.parentNode.removeChild(span);
-        test.parentNode.removeChild(test);
+        script.parentNode.removeChild(script.previousSibling);
         if (script.MathJax.preview) script.MathJax.preview.style.display = "";
       }
       state.CHTMLeqn = state.CHTMLlast = 0; state.CHTMLi = -1;

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -670,7 +670,6 @@
         em = test.childNodes[2].offsetHeight/60;
         cwidth = Math.max(0, jax.HTMLCSS.display ? test.lastChild.offsetWidth - 1: 
                   test.lastChild.offsetLeft - test.firstChild.offsetLeft - 2);
-console.log(em,ex,cwidth);
         if (ex === 0 || ex === "NaN") {
           // can't read width, so move to hidden div for processing
           hidden.push(div);

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -533,11 +533,6 @@
           ["span",{className:"MathJax_left_box"}],
           ["span",{className:"MathJax_ex_box"}],
           ["span",{className:"MathJax_em_box"}],
-	  /* 
-	   * ["span",{className:"MathJax"},
-	   *   [["span",{className:"MathJax_em_box"}]]
-	   * ],
-	   */
           ["span",{className:"MathJax_right_box"}]
         ]
       );

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -118,10 +118,10 @@
         },
         ".MathJax_SVG_test.mjx-test-inline": {
           display:           "inline!important",
-          "margin-right":    "-1px",
+          "margin-right":    "-1px"
         },
         ".MathJax_SVG_test.mjx-test-default": {
-          display: "block",
+          display: "block!important",
           clear:   "both"
         },
         ".MathJax_SVG_ex_box": {

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -101,14 +101,48 @@
         },
         ".MathJax_SVG_Processed": {display:"none!important"},
         
-        ".MathJax_SVG_ExBox": {
-          display:"block!important", overflow:"hidden",
-          width:"1px", height:"60ex",
-          "min-height": 0, "max-height":"none",
-          padding:0, border: 0, margin: 0
+        ".MathJax_SVG_test": {
+          "font-style":      "normal",
+          "font-weight":     "normal",
+          "font-size":       "100%",
+          "font-size-adjust":"none",
+          "text-indent":     0,
+          "text-transform":  "none",
+          "letter-spacing":  "normal",
+          "word-spacing":    "normal",
+          overflow:          "hidden",
+          height:            "1px"
         },
-        ".MathJax_SVG_LineBox": {display: "table!important"},
-        ".MathJax_SVG_LineBox span": {
+        ".MathJax_SVG_test.mjx-test-display": {
+          display: "table!important"
+        },
+        ".MathJax_SVG_test.mjx-test-inline": {
+          display:           "inline!important",
+          "margin-right":    "-1px",
+        },
+        ".MathJax_SVG_test.mjx-test-default": {
+          display: "block",
+          clear:   "both"
+        },
+        ".MathJax_SVG_ex_box": {
+          display: "inline-block!important",
+          position: "absolute",
+          overflow: "hidden",
+          "min-height": 0, "max-height":"none",
+          padding:0, border: 0, margin: 0,
+          width:"1px", height:"60ex"
+        },
+        ".mjx-test-inline .MathJax_SVG_left_box": {
+          display: "inline-block",
+          width: 0,
+          float:"left"
+        },
+        ".mjx-test-inline .MathJax_SVG_right_box": {
+          display: "inline-block",
+          width: 0,
+          float:"right"
+        },
+        ".mjx-test-display .MathJax_SVG_right_box": {
           display: "table-cell!important",
           width: "10000em!important",
           "min-width":0, "max-width":"none",
@@ -181,13 +215,11 @@
                                           "defs",{id:"MathJax_SVG_glyphs"});
 
        // Used in preTranslate to get scaling factors
-      this.ExSpan = HTML.Element("span",
-        {style:{position:"absolute","font-size-adjust":"none"}},
-        [["span",{className:"MathJax_SVG_ExBox"}]]
-      );
-
-      // Used in preTranslate to get linebreak width
-      this.linebreakSpan = HTML.Element("span",{className:"MathJax_SVG_LineBox"},[["span"]]);
+      this.TestSpan = HTML.Element("span",{className:"MathJax_SVG_test"},[
+        ["span",{className:"MathJax_SVG_left_box"}],
+        ["span",{className:"MathJax_SVG_ex_box"}],
+        ["span",{className:"MathJax_SVG_right_box"}]
+      ]);
 
       // Set up styles
       return AJAX.Styles(this.config.styles,["InitializeSVG",this]);
@@ -200,12 +232,11 @@
       //
       //  Get the default sizes (need styles in place to do this)
       //
-      document.body.appendChild(this.ExSpan);
-      document.body.appendChild(this.linebreakSpan);
-      this.defaultEx    = this.ExSpan.firstChild.offsetHeight/60;
-      this.defaultWidth = this.linebreakSpan.firstChild.offsetWidth;
-      document.body.removeChild(this.linebreakSpan);
-      document.body.removeChild(this.ExSpan);
+      var test = document.body.appendChild(this.TestSpan.cloneNode(true));
+      test.className += " mjx-test-inline mjx-test-default";
+      this.defaultEx = test.childNodes[1].offsetHeight/60;
+      this.defaultWidth = Math.max(0,test.lastChild.offsetLeft - test.firstChild.offsetLeft - 2);
+      document.body.removeChild(test);
     },
 
     preTranslate: function (state) {
@@ -261,8 +292,9 @@
         //
         //  Add the test span for determining scales and linebreak widths
         //
-        script.parentNode.insertBefore(this.ExSpan.cloneNode(true),script);
-        div.parentNode.insertBefore(this.linebreakSpan.cloneNode(true),div);
+        test = this.TestSpan.cloneNode(true);
+        test.className += " mjx-test-" + (jax.SVG.display ? "display" : "inline");
+        script.parentNode.insertBefore(test,script);
       }
       //
       //  Determine the scaling factors for each script
@@ -273,14 +305,16 @@
         script = scripts[i]; if (!script.parentNode) continue;
         test = script.previousSibling; div = test.previousSibling;
         jax = script.MathJax.elementJax; if (!jax) continue;
-        ex = test.firstChild.offsetHeight/60;
-        cwidth = Math.max(0,(div.previousSibling.firstChild.offsetWidth-2) / this.config.scale * 100);
+        ex = test.childNodes[1].offsetHeight/60;
+        cwidth = Math.max(0, jax.SVG.display ? test.lastChild.offsetWidth - 1: 
+                  test.lastChild.offsetLeft - test.firstChild.offsetLeft - 2) / this.config.scale * 100;
         if (ex === 0 || ex === "NaN") {
           // can't read width, so move to hidden div for processing
           hidden.push(div);
           jax.SVG.isHidden = true;
           ex = this.defaultEx; cwidth = this.defaultWidth;
         }
+        if (cwidth === 0) cwidth = this.defaultWidth;
         if (relwidth) {maxwidth = cwidth}
         jax.SVG.ex = ex;
         jax.SVG.em = em = ex / SVG.TeX.x_height * 1000; // scale ex to x_height
@@ -296,11 +330,8 @@
       //
       for (i = 0; i < m; i++) {
         script = scripts[i]; if (!script.parentNode) continue;
-        test = scripts[i].previousSibling; span = test.previousSibling;
-        jax = scripts[i].MathJax.elementJax; if (!jax) continue;
-        if (!jax.SVG.isHidden) {span = span.previousSibling}
-        span.parentNode.removeChild(span);
-        test.parentNode.removeChild(test);
+        jax = script.MathJax.elementJax; if (!jax) continue;
+        script.parentNode.removeChild(script.previousSibling);
         if (script.MathJax.preview) script.MathJax.preview.style.display = "";
       }
       //


### PR DESCRIPTION
This PR changes the method of determining the em and ex sizes, and the container width so that display is not set to any block-level values for inline mathematics.  This is fine for the em and ex sizes, but the new mechanism has a downside for finding the container width:  if the inline math is inside a shrink-wrapped element (like a `<td>`, or an element with `display:inline-block`) with no display math, then the container width will be the size of the container without the mathematics, rather than the maximum width available to the shrink-wrapped element, as it is now.  Fortunately, in-line math does not use the container width except in unusual situations (e.g., when there is an explicit line break in the math), so it should not affect most uses.  For those situations where this is a problem, adding an empty display math should resolve the issue (you could put it in a div with height 0px to avoid the extra space it would introduce).

Resolves issue #1982.