### PR TITLE
Fix crash and missing text in recent Safari versions.  #2005

### DIFF
--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -611,7 +611,6 @@
           //
           if (data.preview) {
             data.preview.innerHTML = "";
-            data.preview.style.display = "none";
             script.MathJax.preview = data.preview;
             delete data.preview;
           }

--- a/unpacked/jax/output/HTML-CSS/jax.js
+++ b/unpacked/jax/output/HTML-CSS/jax.js
@@ -767,10 +767,7 @@
         if (script && script.parentNode && script.MathJax.elementJax) {
           var div = (script.MathJax.elementJax.HTMLCSS||{}).div;
           if (div) {div.className = div.className.split(/ /)[0]}
-          if (script.MathJax.preview) {
-            script.MathJax.preview.innerHTML = "";
-            script.MathJax.preview.style.display = "none";
-          }
+          if (script.MathJax.preview) script.MathJax.preview.innerHTML = "";
         }
       }
       //

--- a/unpacked/jax/output/PreviewHTML/jax.js
+++ b/unpacked/jax/output/PreviewHTML/jax.js
@@ -268,7 +268,6 @@
           //
           if (data.preview) {
             data.preview.innerHTML = "";
-            data.preview.style.display = "none";
             script.MathJax.preview = data.preview;
             delete data.preview;
           }

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -402,7 +402,6 @@
           //
           if (data.preview) {
             data.preview.innerHTML = "";
-            data.preview.style.display = "none";
             script.MathJax.preview = data.preview;
             delete data.preview;
           }


### PR DESCRIPTION
Don't set `display:none` on preview elements (since element is empty anyway), as this can cause Safari crashes or intervening text to disappear in some versions of WebKit.
 
Resolves issue #2005.