### PR TITLE
Make sure \big, etc., are at the right size in script styles.  #1987

### DIFF
--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -1611,10 +1611,10 @@
       size *= TEXDEF.p_height;
       size = String(size).replace(/(\.\d\d\d).+/,'$1')+"em";
       var delim = this.GetDelimiter(name,true);
-      this.Push(MML.TeXAtom(MML.mo(delim).With({
+      this.Push(MML.mstyle(MML.TeXAtom(MML.mo(delim).With({
         minsize: size, maxsize: size,
         fence: true, stretchy: true, symmetric: true
-      })).With({texClass: mclass}));
+      })).With({texClass: mclass})).With({scriptlevel: 0}));
     },
     
     BuildRel: function (name) {


### PR DESCRIPTION
Make sure `\big` and friends are in `scriptlevel="0"` so that in script styles the are the correct size.  This currently affects CommonHTML and NativeMML output (HTML-CSS and SVG use units that aren't relative to the script level).

Resolves issue #1987.