### PR TITLE
Fix handing of unbalanced braces in TeX input.  #2036

### DIFF
--- a/unpacked/extensions/tex2jax.js
+++ b/unpacked/extensions/tex2jax.js
@@ -168,7 +168,7 @@ MathJax.Extension.tex2jax = {
                           else {element = this.endMatch(match,element)}
       }
       if (this.search.matched) element = this.encloseMath(element);
-        else if (!this.search.start) rescan = this.search;
+        else if (!this.search.start && !this.search.close) rescan = this.search;
       if (element) {
         do {prev = element; element = element.nextSibling}
           while (element && this.ignoreTags[element.nodeName.toLowerCase()] != null);


### PR DESCRIPTION
Fix handing of unbalanced braces in TeX input cause by #1960 in 2.7.4.

Resolves #2036.