### PR TITLE
Support TeX-in-<math>-tags, a la Wikipedia's math markdown.

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -16,8 +16,15 @@
 //
   MathJax.HTML.Cookie.Set("menu",{});
   MathJax.Hub.Config({
-    extensions: ["tex2jax.js"],
+    extensions: ["mml2jax.js", "tex2jax.js"],
     jax: ["input/TeX","output/HTML-CSS"],
+    mml2jax: {
+      outputTex: true
+    },
+    tex2jax: {
+      inlineMath: [['\\(', '\\)']],
+      displayMath: [['$$', '$$'], ['\\[', '\\]']],
+    },
     "HTML-CSS": {
       availableFonts:[],
       styles: {".MathJax_Preview": {visibility: "hidden"}}
@@ -98,6 +105,12 @@ TeX code instead, MathJax is not working for you.
 <!------------------------------------------------------------------------>
 <hr>
 
+
+<p>
+<math mode="display">
+\frac{-b\pm\sqrt{b^2-4ac}}{2a}
+</math>
+</p>
 
 <p>
 \[

--- a/unpacked/extensions/mml2jax.js
+++ b/unpacked/extensions/mml2jax.js
@@ -29,14 +29,15 @@
 MathJax.Extension.mml2jax = {
   version: "2.7.5",
   config: {
-    preview: "mathml"       // Use the <math> element as the
+    preview: "mathml",      // Use the <math> element as the
                             //   preview.  Set to "none" for no preview,
                             //   set to "alttext" to use the alttext attribute
                             //   of the <math> element, set to "altimg" to use
                             //   an image described by the altimg* attributes
                             //   or set to an array specifying an HTML snippet
                             //   to use a fixed preview for all math
-
+    outputTex: false        // Produce "math/tex" script tags instead of
+                            //   "math/mml" script tags.
   },
   MMLnamespace: "http://www.w3.org/1998/Math/MathML",
   
@@ -122,18 +123,34 @@ MathJax.Extension.mml2jax = {
     var parent = math.parentNode;
     if (!parent || parent.className === MathJax.Hub.config.preRemoveClass) return;
     var script = document.createElement("script");
-    script.type = "math/mml";
+    if (this.config.outputTex) {
+      script.type = "math/tex";
+      if (math.hasAttribute("mode")) {
+        script.type += "; mode=" + math.getAttribute("mode");
+      }
+    } else {
+      script.type = "math/mml";
+    }
     parent.insertBefore(script,math);
-    if (this.AttributeBug) {
-      var html = this.OuterHTML(math);
-      if (this.CleanupHTML) {
+    if (this.config.outputTex) {
+      var html = math.innerHTML;
+      if (this.AttributeBug && this.CleanupHTML) {
         html = html.replace(/<\?import .*?>/i,"").replace(/<\?xml:namespace .*?\/>/i,"");
         html = html.replace(/&nbsp;/g,"&#xA0;");
       }
-      MathJax.HTML.setScript(script,html); parent.removeChild(math);
+      MathJax.HTML.setScript(script, html); parent.removeChild(math);
     } else {
-      var span = MathJax.HTML.Element("span"); span.appendChild(math);
-      MathJax.HTML.setScript(script,span.innerHTML);
+      if (this.AttributeBug) {
+        var html = this.OuterHTML(math);
+        if (this.CleanupHTML) {
+          html = html.replace(/<\?import .*?>/i,"").replace(/<\?xml:namespace .*?\/>/i,"");
+          html = html.replace(/&nbsp;/g,"&#xA0;");
+        }
+        MathJax.HTML.setScript(script,html); parent.removeChild(math);
+      } else {
+        var span = MathJax.HTML.Element("span"); span.appendChild(math);
+        MathJax.HTML.setScript(script,span.innerHTML);
+      }
     }
     if (this.config.preview !== "none") {this.createPreview(math,script)}
   },


### PR DESCRIPTION
This minor change in `mml2jax` allows you to write inline math markup just like you would on Wikipedia or Stack Overflow: `<math>1+2=3</math>`. We accomplish this by mixing the "mml2jax" preprocessor (which knows how to find math tags) with the "tex" middle-end (which knows how to render TeX input).

The one complication is that the TeX middle-end expects to see the text *without* the surrounding `<math> ... </math>`, whereas the MathML middle-end expects to see it *with* the surrounding `<math> ... </math>`. So if we're outputting to the TeX middle-end, we need to take `innerHTML` instead of `outerHTML`.

To test the functionality, copy `mml2jax.js` from `unpacked/extensions/` into `extensions/`, and then open `index.html` in a Web browser. You should see two identical display-mode equations: one rendered by `<math mode=display> ... </math>` and one rendered by `\[ ... \]`.

I plan to use this extension on my blog, which uses Jekyll, and where I don't trust myself to avoid writing `\(` or `\[` or `$$` by accident. Whereas I definitely do trust myself to never write `<math>` by accident!

Fixes #2043.