### PR TITLE
Put back old color properly in \color macro

### DIFF
--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -1328,7 +1328,7 @@
       var color = this.GetArgument(name);
       var old = this.stack.env.color; this.stack.env.color = color;
       var math = this.ParseArg(name);
-      if (old) {this.stack.env.color} else {delete this.stack.env.color}
+      if (old) {this.stack.env.color = old} else {delete this.stack.env.color}
       this.Push(MML.mstyle(math).With({mathcolor: color}));
     },
     


### PR DESCRIPTION
The assignment seems to be missing from the original code.  Fortunately, it doesn't affect too many situations.