### PR TITLE
Properly handle 'fit' columns in percentage-width tables.

### DIFF
--- a/unpacked/jax/output/CommonHTML/autoload/mtable.js
+++ b/unpacked/jax/output/CommonHTML/autoload/mtable.js
@@ -362,7 +362,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       //
       //  Adjust widths of columns
       //
-      if (setWidths) {
+      if (setWidths || (relWidth && hasFit)) {
         if (relWidth) {
           //
           //  Attach appropriate widths to the columns


### PR DESCRIPTION
Without this, tables with width equal to a percentage that have column widths that are `fit` will not have the fit columns stretch properly.

A test case is:

```
<math display="block">
  <mtable width="100%" columnwidth="3em fit 3em">
    <mtr>
      <mtd mathbackground="red"><mi>x</mi></mtd>
      <mtd mathbackground="yellow"><mi>x</mi></mtd>
      <mtd mathbackground="red"><mi>x</mi></mtd>
    </mtr>
  </mtable>
</math>
```

Without the patch, the two outer (red) cells will be too wide.  With the patch, the inner (yellow) cell will stretch to fill all the extra space.