### PR TITLE
Scale mglyphs to proper script size. 

### DIFF
--- a/unpacked/jax/output/HTML-CSS/autoload/mglyph.js
+++ b/unpacked/jax/output/HTML-CSS/autoload/mglyph.js
@@ -69,17 +69,18 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
           span.bbox = err.HTMLspanElement().bbox;
         } else {
           var mu = this.HTMLgetMu(span);
+          var scale = this.HTMLgetScale();
           img = HTMLCSS.addElement(span,"img",{isMathJax:true, src:values.src, alt:values.alt, title:values.alt});
           if (values.width)  {
-            img.style.width = HTMLCSS.Em(HTMLCSS.length2em(values.width,mu,this.img.img.width/HTMLCSS.em));
+            img.style.width = HTMLCSS.Em(HTMLCSS.length2em(values.width,mu,this.img.img.width/HTMLCSS.em) * scale);
           }
           if (values.height) {
-            img.style.height = HTMLCSS.Em(HTMLCSS.length2em(values.height,mu,this.img.img.height/HTMLCSS.em));
+            img.style.height = HTMLCSS.Em(HTMLCSS.length2em(values.height,mu,this.img.img.height/HTMLCSS.em) * scale);
           }
           span.bbox.w = span.bbox.rw = img.offsetWidth/HTMLCSS.em;
           span.bbox.h = img.offsetHeight/HTMLCSS.em;
           if (values.valign) {
-            span.bbox.d = -HTMLCSS.length2em(values.valign,mu,this.img.img.height/HTMLCSS.em);
+            span.bbox.d = -HTMLCSS.length2em(values.valign,mu,this.img.img.height/HTMLCSS.em) * scale;
             img.style.verticalAlign = HTMLCSS.Em(-span.bbox.d);
             span.bbox.h -= span.bbox.d;
           }

--- a/unpacked/jax/output/SVG/autoload/mglyph.js
+++ b/unpacked/jax/output/SVG/autoload/mglyph.js
@@ -35,13 +35,13 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
 
   BBOX.MGLYPH = BBOX.Subclass({
     type: "image", removeable: false,
-    Init: function (img,w,h,align,mu,def) {
+    Init: function (img,w,h,align,mu,scale,def) {
       if (def == null) {def = {}}
       var W = img.width*1000/SVG.em, H = img.height*1000/SVG.em;
       var WW = W, HH = H, y = 0;
-      if (w !== "") {W = SVG.length2em(w,mu,WW); H = (WW ? W/WW * HH : 0)}
-      if (h !== "") {H = SVG.length2em(h,mu,HH); if (w === "") {W = (HH ? H/HH * WW : 0)}}
-      if (align !== "" && align.match(/\d/)) {y = SVG.length2em(align,mu); def.y = -y}
+      if (w !== "") {W = SVG.length2em(w,mu,WW) * scale; H = (WW ? W/WW * HH : 0)}
+      if (h !== "") {H = SVG.length2em(h,mu,HH) * scale; if (w === "") {W = (HH ? H/HH * WW : 0)}}
+      if (align !== "" && align.match(/\d/)) {y = SVG.length2em(align,mu) * scale; def.y = -y}
       def.height = Math.floor(H); def.width = Math.floor(W);
       def.transform = "translate(0,"+H+") matrix(1 0 0 -1 0 0)";
       def.preserveAspectRatio = "none";
@@ -81,7 +81,8 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
           this.Append(err); svg = err.toSVG(); this.data.pop();
         } else {
           var mu = this.SVGgetMu(svg);
-          svg.Add(BBOX.MGLYPH(this.img.img,values.width,values.height,values.valign,mu,
+          var SCALE = this.SVGgetScale();
+          svg.Add(BBOX.MGLYPH(this.img.img,values.width,values.height,values.valign,mu,SCALE,
                               {'aria-label':values.alt}));
         }
       }


### PR DESCRIPTION
This PR scales glyphs when they are used in situations where the scaling is not 1, like super- and subscript or fractions in text style.  See the original issue for a test case.

 Resolves issue #2124.