### PR TITLE
Move mathjax-full to a dev-dependency.  #2242

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "make-es5": "npm run --silent install:all && npm run --silent compile && npm run --silent components && npm run --silent move",
     "postmake-es5": "npm run --silent title --mathjax:title='Cleaning Up...' && npm run --silent clean:node"
   },
-  "dependencies": {
+  "devDependencies": {
     "mathjax-full": "git://github.com/mathjax/MathJax-src.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "browser",
     "node"
   ],
+  "devDependencies": {
+    "mathjax-full": "3.0.0"
+  },
   "maintainers": [
     "MathJax Consortium <info@mathjax.org> (http://www.mathjax.org)"
   ],
@@ -36,7 +39,7 @@
     "line": "echo '--------------------------------------------'",
     "title": "npm run --silent line && npm run --silent message --mathjax:message=\"${npm_package_config_title}\"",
     "preinstall:mj3": "npm run --silent title --mathjax:title='Installing MathJax...'",
-    "install:mj3": "npm install git://github.com/mathjax/MathJax-src",
+    "install:mj3": "npm install",
     "preinstall:mj3-deps": "npm run --silent message --mathjax:message='Installing MathJax Dependencies...'",
     "install:mj3-deps": "cd node_modules/mathjax-full && npm install",
     "install:all": "npm run --silent install:mj3 && npm run --silent install:mj3-deps",
@@ -48,9 +51,9 @@
     "move": "npm run --silent clean:es5 && mv node_modules/mathjax-full/es5 .",
     "premake-es5": "npm run --silent clean:node",
     "make-es5": "npm run --silent install:all && npm run --silent compile && npm run --silent components && npm run --silent move",
-    "postmake-es5": "npm run --silent title --mathjax:title='Cleaning Up...' && npm run --silent clean:node"
-  },
-  "devDependencies": {
-    "mathjax-full": "git://github.com/mathjax/MathJax-src.git"
+    "postmake-es5": "npm run --silent title --mathjax:title='Cleaning Up...' && npm run --silent clean:node",
+    "preget-es5": "npm run --silent clean:node",
+    "get-es5": "npm run --silent install:mj3 && npm run --silent move",
+    "postget-es5": "npm run --silent title --mathjax:title='Cleaning Up...' && npm run --silent clean:node"
   }
 }


### PR DESCRIPTION
Change `mathjax-ful`l dependency to a devDependency, so `mathjax-full` (and its dependencies) are not loaded when `mathjax` is included in a node project.

Resolves issue #2242