### PR TITLE
Fix over-wide SVG output when \vphantom is used.  (#1637)

### DIFF
--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -1529,13 +1529,13 @@
     },
     
     Phantom: function (name,v,h) {
-      var box = MML.mphantom(this.ParseArg(name));
+      var mml = this.ParseArg(name);
       if (v || h) {
-        box = MML.mpadded(box);
-        if (h) {box.height = box.depth = 0}
-        if (v) {box.width = 0}
+        mml = MML.mpadded(mml);
+        if (h) {mml.height = mml.depth = 0}
+        if (v) {mml.width = 0}
       }
-      this.Push(MML.TeXAtom(box));
+      this.Push(MML.TeXAtom(MML.mphantom(mml)));
     },
     
     Smash: function (name) {

--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -1750,7 +1750,10 @@
 	if (this.data[0] != null) {
           this.SVGhandleSpace(svg); svg.Add(this.SVGdataStretched(0,HW,D)); svg.Clean();
           while (svg.element.firstChild) {svg.element.removeChild(svg.element.firstChild)}
-	}
+          svg.D = svg.d; svg.H = svg.h;
+          svg.r = Math.max(0, Math.min(svg.w, svg.r));
+          svg.l = Math.max(0, Math.min(svg.w, svg.l));
+        }
 	this.SVGhandleColor(svg);
         this.SVGsaveData(svg);
         if (svg.removeable && !svg.element.firstChild) {delete svg.element}


### PR DESCRIPTION
This PR switches the order of `mpadded` and `mphantom` in `\vphantom` and `\hphantom` in order to allow `mphantom` to remove the width (and height) of the phantom content from the bounding box overflow data (since it will not be visible).

This will require that some tests be modified, since the underlying MathML is changed.

Resolves issue #1637. 