### PR TITLE
Add CSS to fix RTL issue in Chrome.  (#2190)

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -1893,7 +1893,10 @@ MathJax.Hub = {
     config: [],      // list of configuration files to load
     styleSheets: [], // list of CSS files to load
     styles: {        // styles to generate in-line
-      ".MathJax_Preview": {color: "#888"}
+      ".MathJax_Preview": {
+        color: "#888",
+        display: "contents" // for RTL languages in Chrome (see issue #2190)
+      }
     },
     jax: [],         // list of input and output jax to load
     extensions: [],  // list of extensions to load


### PR DESCRIPTION
This PR adds CSS so that the MathJax preview spans don't cause problems with RTL languages in Chrome.

Resolves issue #2190.