### PR TITLE
Remove references to cdn.mathjax.org. (#2160)

### DIFF
--- a/unpacked/MathJax.js
+++ b/unpacked/MathJax.js
@@ -667,7 +667,6 @@ MathJax.cdnFileVersions = {};  // can be used to specify revisions for individua
   var PATH = {};
   PATH[BASENAME] = "";                                        // empty path gets the root URL
   PATH.a11y = '[MathJax]/extensions/a11y';                    // a11y extensions
-  PATH.Contrib = "https://cdn.mathjax.org/mathjax/contrib";   // the third-party extensions
 
   BASE.Ajax = {
     loaded: {},         // files already loaded

--- a/unpacked/config/Safe.js
+++ b/unpacked/config/Safe.js
@@ -9,7 +9,7 @@
  *  when you load MathJax.js, e.g.
  *  
  *  <script
- *    src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML,Safe">
+ *    src="http://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS_HTML,Safe">
  *  </script>
  *
  *  ---------------------------------------------------------------------


### PR DESCRIPTION
This removes the Contrib path (not active for several years).

Resolves issue #2160.