### PR TITLE
Add missing stretchy character data.  (#2135)

### DIFF
--- a/unpacked/jax/output/HTML-CSS/fonts/STIX/fontdata.js
+++ b/unpacked/jax/output/HTML-CSS/fonts/STIX/fontdata.js
@@ -391,7 +391,8 @@
         0x0332: {alias: 0x23AF, dir:H}, // combining low line
         0x2015: {alias: 0x23AF, dir:H}, // horizontal line
         0x2017: {alias: 0x23AF, dir:H}, // horizontal line
-        0x20D7: {alias: 0x2192, dir:H}, // combinining over right arrow (vector arrow)
+        0x20D6: {alias: 0x2190, dir:H}, // combining over left arrow
+        0x20D7: {alias: 0x2192, dir:H}, // combining over right arrow (vector arrow)
         0x2212: {alias: 0x23AF, dir:H}, // minus
         0x2215: {alias: 0x002F, dir:V}, // division slash
         0x2329: {alias: 0x27E8, dir:V}, // langle


### PR DESCRIPTION
This adds the missing data for stretchy combining over left arrow (U+20D6).

Resolves issue #2135.