### PR TITLE
Allow tex2jax end delimiters to be close braces.  (#2034)

### DIFF
--- a/unpacked/extensions/tex2jax.js
+++ b/unpacked/extensions/tex2jax.js
@@ -235,7 +235,7 @@ MathJax.Extension.tex2jax = {
         this.switchPattern(this.start);
       }
     }
-    else if (match[0] === "{") {search.pcount++}
+    if (match[0] === "{") {search.pcount++}
     else if (match[0] === "}" && search.pcount) {search.pcount--}
     return element;
   },


### PR DESCRIPTION
This allows delimiters like

```
   tex2jax: {inlineMath: ['\\equation{', '}']}
```

to be valid.

Resolves issue #2034.