### PR TITLE
Proper spacing for mstyle containing stretchy operator. (#2052)

### DIFF
--- a/unpacked/jax/output/SVG/jax.js
+++ b/unpacked/jax/output/SVG/jax.js
@@ -1828,23 +1828,17 @@
     });
 
     MML.mstyle.Augment({
-      toSVG: function () {
+      toSVG: function (HW,D) {
         this.SVGgetStyles();
         var svg = this.SVG();
 	if (this.data[0] != null) {
           this.SVGhandleSpace(svg);
-          var math = svg.Add(this.data[0].toSVG()); svg.Clean();
+          var math = svg.Add(this.data[0].toSVG(HW,D)); svg.Clean();
           if (math.ic) {svg.ic = math.ic}
 	  this.SVGhandleColor(svg);
 	}
         this.SVGsaveData(svg);
 	return svg;
-      },
-      SVGstretchH: function (w) {
-	return (this.data[0] != null ? this.data[0].SVGstretchH(w) : BBOX.NULL());
-      },
-      SVGstretchV: function (h,d) {
-	return (this.data[0] != null ? this.data[0].SVGstretchV(h,d) : BBOX.NULL());
       }
     });
 


### PR DESCRIPTION
The spacing (and background color, etc.) were being set for `mstyle` elements prior to their contents being stretched, and was lost during the stretching process.  This PR fixes the problem by using the main `toSVG()` function rather than separate stretching functions.  The `HW` and `D` parameters are only passed when the `mstyle` is an embellished operator that is being stretched.

Resolves issue #2052.