### PR TITLE
Fix scaling of enclosures in zoomed CHTML.  (#1815)

### DIFF
--- a/unpacked/jax/output/CommonHTML/autoload/menclose.js
+++ b/unpacked/jax/output/CommonHTML/autoload/menclose.js
@@ -111,6 +111,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
           rx:CHTML.Px(W/2-t/2), ry:CHTML.Px((H+D)/2-t/2),
           cx:CHTML.Px(W/2),   cy:CHTML.Px((H+D)/2)
         });
+        this.CHTMLsvgViewBox(svg);
       },
 
       /********************************************************/
@@ -187,6 +188,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
         this.CHTMLsvgElement(svg.firstChild,"line",{
           x1:CHTML.Px(t/2), y1:CHTML.Px(H+D-t), x2:CHTML.Px(W-t), y2:CHTML.Px(t/2)
         });
+        this.CHTMLsvgViewBox(svg);
       },
 
       /********************************************************/
@@ -197,6 +199,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
         this.CHTMLsvgElement(svg.firstChild,"line",{
           x1:CHTML.Px(t/2), y1:CHTML.Px(t/2), x2:CHTML.Px(W-t), y2:CHTML.Px(H+D-t)
         });
+        this.CHTMLsvgViewBox(svg);
       },
 
       /********************************************************/
@@ -221,6 +224,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
              "L "+this.CHTMLpx(R-x-dx)+","+this.CHTMLpx(-y),
           stroke:"none"
         });
+        this.CHTMLsvgViewBox(svg);
       },
 
       /********************************************************/
@@ -235,6 +239,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
           d: "M "+this.CHTMLpx(p)+",1 " +
              "L 1,"+this.CHTMLpx(H+D-t)+" L "+this.CHTMLpx(W)+","+this.CHTMLpx(H+D-t)
         });
+        this.CHTMLsvgViewBox(svg);
       },
 
       /********************************************************/
@@ -248,6 +253,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
           d: "M "+this.CHTMLpx(W)+",1 L 1,1 "+
              "a"+this.CHTMLpx(p)+","+this.CHTMLpx((H+D)/2-t/2)+" 0 0,1 1,"+this.CHTMLpx(H+D-1.5*t)
         });
+        this.CHTMLsvgViewBox(svg);
       },
 
       /********************************************************/
@@ -262,6 +268,7 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
              " L "+this.CHTMLpx(p)+","+this.CHTMLpx(H+D) +
              " L "+this.CHTMLpx(2*p)+",1 L "+this.CHTMLpx(W)+",1"
         });
+        this.CHTMLsvgViewBox(svg);
       }
 
       /********************************************************/
@@ -295,6 +302,11 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       }
       node.parentNode.appendChild(svg);
       return svg;
+    },
+    //
+    CHTMLsvgViewBox(svg) {
+      var bbox = svg.getBBox();
+      svg.setAttribute('viewBox', [bbox.x, bbox.y, bbox.width, bbox.height].join(' '));
     },
     //
     //  Add an SVG element to the given svg node

--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -126,7 +126,7 @@
     
     ".mjx-annotation-xml": {"line-height":"normal"},
     
-    ".mjx-menclose > svg": {fill:"none", stroke:"currentColor"},
+    ".mjx-menclose > svg": {fill:"none", stroke:"currentColor", overflow:"visible"},
 
     ".mjx-mtr":    {display:"table-row"},
     ".mjx-mlabeledtr": {display:"table-row"},


### PR DESCRIPTION
This fixes the scaling problem with SVG-based enclosures for `menclose` in CHTML output.  Zoomed output should now scale properly.

Resolves issue #1815.
