### PR TITLE
Make line breaks cause full-width box when they are at the top level. (#1804)

### DIFF
--- a/unpacked/jax/output/CommonHTML/autoload/multiline.js
+++ b/unpacked/jax/output/CommonHTML/autoload/multiline.js
@@ -125,7 +125,9 @@ MathJax.Hub.Register.StartupHook("CommonHTML Jax Ready",function () {
       state.isLast = true;
       this.CHTMLaddLine(stack,start,[],state,ENDVALUES,broken);
 
-      node.style.width = stack.style.width = this.CHTML.pwidth = "100%";
+      if (parent.type === "math") {
+        node.style.width = stack.style.width = this.CHTML.pwidth = "100%";
+      }
       this.CHTML.mwidth = CHTML.Em(this.CHTML.w);
       this.CHTML.isMultiline = parent.CHTML.isMultiline = true;
       stack.style.verticalAlign = CHTML.Em(state.d - this.CHTML.d);

--- a/unpacked/jax/output/HTML-CSS/autoload/multiline.js
+++ b/unpacked/jax/output/HTML-CSS/autoload/multiline.js
@@ -129,10 +129,7 @@ MathJax.Hub.Register.StartupHook("HTML-CSS Jax Ready",function () {
       //  Make top-level spans 100% wide.
       //  Finish up the space and add the color again
       //
-      if (isTop) {
-        stack.style.width = "100%";
-        if (parent.type === "math") {span.bbox.width = "100%"}
-      }
+      if (parent.type === "math") {stack.style.width = span.bbox.width = "100%"}
       this.HTMLhandleSpace(span);
       this.HTMLhandleColor(span);
       span.bbox.isMultiline = true;

--- a/unpacked/jax/output/SVG/autoload/multiline.js
+++ b/unpacked/jax/output/SVG/autoload/multiline.js
@@ -94,7 +94,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
       //    in the top-level math element
       //
       svg = this.SVG();
-      if (isTop && parent.type !== "mtd") {
+      if (parent.type === "math") {
         if (SVG.linebreakWidth < SVG.BIGDIMEN) {svg.w = SVG.linebreakWidth}
           else {svg.w = SVG.cwidth}
       }


### PR DESCRIPTION
This PR makes HTML-CSS, CHTML, and SVG output produce the same results for when `\\` is used outside of arrays and alignments.  If the `\\` is at the top level, it will produce a full-width box (so that if used in-line, you will not get strange artifacts due to the width being smaller than the line width), but if used internally, it will have a tight bounding box.  So `text $a\\b$ text` should produce

```
text
a
b
text
```

rather than

```
text a text
     b
```

or

```
text
a text
b
```

as currently happens in SVG and HTML-CSS output.

Resolves issue #1804 and #1802.