### PR TITLE
[v2] Don't add \text to operators whose name already include it.  (#2222)

### DIFF
--- a/unpacked/extensions/TeX/AMSmath.js
+++ b/unpacked/extensions/TeX/AMSmath.js
@@ -223,14 +223,14 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
       var cs = this.trimSpaces(this.GetArgument(name));
       if (cs.charAt(0) == "\\") {cs = cs.substr(1)}
       var op = this.GetArgument(name);
-      op = op.replace(/\*/g,'\\text{*}').replace(/-/g,'\\text{-}');
+      if (!op.match(/\\text/)) op = op.replace(/\*/g,'\\text{*}').replace(/-/g,'\\text{-}');
       this.setDef(cs, ['Macro', '\\mathop{\\rm '+op+'}'+limits]);
     },
     
     HandleOperatorName: function (name) {
       var limits = (this.GetStar() ? "" : "\\nolimits\\SkipLimits");
       var op = this.trimSpaces(this.GetArgument(name));
-      op = op.replace(/\*/g,'\\text{*}').replace(/-/g,'\\text{-}');
+      if (!op.match(/\\text/)) op = op.replace(/\*/g,'\\text{*}').replace(/-/g,'\\text{-}');
       this.string = '\\mathop{\\rm '+op+'}'+limits+" "+this.string.slice(this.i);
       this.i = 0;
     },


### PR DESCRIPTION
This PR prevents Mathjax from inserting another `\text{}` into an operator name that already has `\text{}` in it.  It is not perfect, in that this does allow `-` and `*` to be rendered as mathematics in cases where LaTeX doesn't (e.g., `\operatorname{\text{a}-\text{b}}`), but is probably good enough for MathJax.

Resolves issue #2222.