### PR TITLE
Fix displayIndent in CHTML with floating elements.  (#2352)

### DIFF
--- a/unpacked/jax/output/CommonHTML/jax.js
+++ b/unpacked/jax/output/CommonHTML/jax.js
@@ -1866,11 +1866,12 @@
           node.parentNode.style.textAlign = styles.textAlign = values.indentalign;
           // ### FIXME: make percentage widths respond to changes in container
           if (shift) {
+            if (values.indentalign === 'right') node.style.marginRight = CHTML.Em(-shift);
             shift *= CHTML.em/CHTML.outerEm;
             HUB.Insert(styles,({
-              left: {marginLeft: CHTML.Em(shift)},
-              right: {marginRight: CHTML.Em(-shift)},
-              center: {marginLeft: CHTML.Em(shift), marginRight: CHTML.Em(-shift)}
+              left: {textIndent: CHTML.Em(shift)},
+              right: {display: 'flex', flexDirection: 'row-reverse'},
+              center: {textIndent: CHTML.Em(2*shift)}
             })[values.indentalign]);
           }
         }


### PR DESCRIPTION
This PR fixes a problem with `displayIndent` in CHTML when the expression has a floating element to the left or right.  In the past, the indent was lost behind the floating element.

Resolves issue #2352.