### PR TITLE
Make \overset and friends mark mo as non-accents (#2800)

### DIFF
--- a/unpacked/jax/input/TeX/jax.js
+++ b/unpacked/jax/input/TeX/jax.js
@@ -822,6 +822,7 @@
 
         overset:            'Overset',
         underset:           'Underset',
+        overunderset:       'Overunderset',
         stackrel:           ['Macro','\\mathrel{\\mathop{#2}\\limits^{#1}}',2],
           
         over:               'Over',
@@ -1466,12 +1467,17 @@
     Overset: function (name) {
       var top = this.ParseArg(name), base = this.ParseArg(name);
       base.movablelimits = false;
-      this.Push(MML.mover(base,top));
+      this.Push(MML.mover(base,top).With({accent:false}));
     },
     Underset: function (name) {
       var bot = this.ParseArg(name), base = this.ParseArg(name);
       base.movablelimits = false;
-      this.Push(MML.munder(base,bot));
+      this.Push(MML.munder(base,bot).With({accentunder:false}));
+    },
+    Overunderset: function (name) {
+      var top = this.ParseArg(name), bot = this.ParseArg(name), base = this.ParseArg(name);
+      base.movablelimits = false;
+      this.Push(MML.munder(base,bot,top).With({accent:false, accentunder:false}));
     },
     
     TeXAtom: function (name,mclass) {


### PR DESCRIPTION
If the top or bottom of \overset, \underset or \overunderset is a single mo element whose operator-dictionary entry indicates it is an accent by default, then the output is incorrect (the display uses accent size and spacing, and accent substitution can be performed). This PR resolves that buy explicitly marking mo elements with accent="false". This will be filtered out if that is the operator dictionary default, but will be retained otherwise.

Resolves issue #2800.

Companion to mathjax/MathJax-src#763.