### PR TITLE
Localize some AsciiMath variables that should not be global. (#2748)

### DIFF
--- a/unpacked/jax/input/AsciiMath/jax.js
+++ b/unpacked/jax/input/AsciiMath/jax.js
@@ -1389,10 +1389,10 @@ asciimath.translate = translate;
  *
  ******************************************************************/
 
-showasciiformulaonhover = false;
-mathfontfamily = "";
-mathcolor = "";
-mathfontsize = "";
+var showasciiformulaonhover = false;
+var mathfontfamily = "";
+var mathcolor = "";
+var mathfontsize = "";
 
 //
 //  Remove remapping of mathvariants to plane1 (MathJax handles that)


### PR DESCRIPTION
This makes some variables local that were accidentally global in the AsciiMath input jax.

Resolve issue #2748.